### PR TITLE
feat: update data without limitation of min 50 occurences

### DIFF
--- a/data/2024-06-01-entity-scripting.json
+++ b/data/2024-06-01-entity-scripting.json
@@ -1,0 +1,8240 @@
+[{
+  "canonicalDomain": "*.googletagmanager.com",
+  "totalExecutionTime": "5570433648.3959837",
+  "totalOccurrences": "7862343",
+  "totalScripts": "18239681",
+  "averageExecutionTime": "708.49537452079915",
+  "averageScriptExecutionTime": "310.80271938406071"
+}, {
+  "canonicalDomain": "*.google-analytics.com",
+  "totalExecutionTime": "507048001.69499964",
+  "totalOccurrences": "4492386",
+  "totalScripts": "4691834",
+  "averageExecutionTime": "112.86830688524978",
+  "averageScriptExecutionTime": "108.44460165708762"
+}, {
+  "canonicalDomain": "ajax.googleapis.com",
+  "totalExecutionTime": "3534531229.4199805",
+  "totalOccurrences": "3340383",
+  "totalScripts": "5007145",
+  "averageExecutionTime": "1058.1215475650497",
+  "averageScriptExecutionTime": "884.70440141665335"
+}, {
+  "canonicalDomain": "*.facebook.com",
+  "totalExecutionTime": "1232870228.5660019",
+  "totalOccurrences": "3181100",
+  "totalScripts": "7844471",
+  "averageExecutionTime": "387.56097845588022",
+  "averageScriptExecutionTime": "143.93389041787634"
+}, {
+  "canonicalDomain": "accounts.google.com",
+  "totalExecutionTime": "891489978.66600049",
+  "totalOccurrences": "2358413",
+  "totalScripts": "4707382",
+  "averageExecutionTime": "378.00418275594694",
+  "averageScriptExecutionTime": "174.63502104758328"
+}, {
+  "canonicalDomain": "maps.google.com",
+  "totalExecutionTime": "768992258.71499956",
+  "totalOccurrences": "1214682",
+  "totalScripts": "4633020",
+  "averageExecutionTime": "633.08113458090236",
+  "averageScriptExecutionTime": "151.81676789547762"
+}, {
+  "canonicalDomain": "adservice.google.com",
+  "totalExecutionTime": "3480575845.5289841",
+  "totalOccurrences": "1186867",
+  "totalScripts": "10202574",
+  "averageExecutionTime": "2932.574454870668",
+  "averageScriptExecutionTime": "288.51317076772779"
+}, {
+  "canonicalDomain": "*.youtube.com",
+  "totalExecutionTime": "4803269961.9261541",
+  "totalOccurrences": "962443",
+  "totalScripts": "4690137",
+  "averageExecutionTime": "4990.7059035456095",
+  "averageScriptExecutionTime": "925.43734725567913"
+}, {
+  "canonicalDomain": "*.jquery.com",
+  "totalExecutionTime": "272881723.94600052",
+  "totalOccurrences": "713886",
+  "totalScripts": "796301",
+  "averageExecutionTime": "382.24831968409609",
+  "averageScriptExecutionTime": "349.31578350840721"
+}, {
+  "canonicalDomain": "cdnjs.cloudflare.com",
+  "totalExecutionTime": "317590713.2870236",
+  "totalOccurrences": "618006",
+  "totalScripts": "792921",
+  "averageExecutionTime": "513.89584128151409",
+  "averageScriptExecutionTime": "384.07065417376054"
+}, {
+  "canonicalDomain": "mc.yandex.ru",
+  "totalExecutionTime": "1132490119.5050073",
+  "totalOccurrences": "596366",
+  "totalScripts": "680464",
+  "averageExecutionTime": "1898.9850519731326",
+  "averageScriptExecutionTime": "1738.0778927211386"
+}, {
+  "canonicalDomain": "*.parastorage.com",
+  "totalExecutionTime": "2140312529.8329959",
+  "totalOccurrences": "447776",
+  "totalScripts": "7963145",
+  "averageExecutionTime": "4779.8732621511617",
+  "averageScriptExecutionTime": "259.27504724102118"
+}, {
+  "canonicalDomain": "fundingchoices.mgr.consensu.org",
+  "totalExecutionTime": "225244113.42899954",
+  "totalOccurrences": "376042",
+  "totalScripts": "857326",
+  "averageExecutionTime": "598.98658508623976",
+  "averageScriptExecutionTime": "290.15058509681961"
+}, {
+  "canonicalDomain": "*.jsdelivr.net",
+  "totalExecutionTime": "221627302.49500453",
+  "totalOccurrences": "348983",
+  "totalScripts": "411785",
+  "averageExecutionTime": "635.06618515803018",
+  "averageScriptExecutionTime": "533.21413715501114"
+}, {
+  "canonicalDomain": "ajax.cloudflare.com",
+  "totalExecutionTime": "43646292.915999986",
+  "totalOccurrences": "348270",
+  "totalScripts": "374240",
+  "averageExecutionTime": "125.32314846527106",
+  "averageScriptExecutionTime": "115.77296937328312"
+}, {
+  "canonicalDomain": "*.clarity.ms",
+  "totalExecutionTime": "121291177.7270001",
+  "totalOccurrences": "338320",
+  "totalScripts": "340685",
+  "averageExecutionTime": "358.51022028552927",
+  "averageScriptExecutionTime": "356.46250519823491"
+}, {
+  "canonicalDomain": "*.vine.co",
+  "totalExecutionTime": "724500215.280013",
+  "totalOccurrences": "331517",
+  "totalScripts": "1562476",
+  "averageExecutionTime": "2185.4089391494663",
+  "averageScriptExecutionTime": "257.44343529159136"
+}, {
+  "canonicalDomain": "*.hotjar.com",
+  "totalExecutionTime": "218863773.43899944",
+  "totalOccurrences": "331044",
+  "totalScripts": "343716",
+  "averageExecutionTime": "661.1319747193719",
+  "averageScriptExecutionTime": "642.52179723458778"
+}, {
+  "canonicalDomain": "*.wordpress.com",
+  "totalExecutionTime": "200848135.63900006",
+  "totalOccurrences": "311147",
+  "totalScripts": "650082",
+  "averageExecutionTime": "645.50882907114612",
+  "averageScriptExecutionTime": "359.06027035721246"
+}, {
+  "canonicalDomain": "*.fontawesome.com",
+  "totalExecutionTime": "67991656.496999979",
+  "totalOccurrences": "310456",
+  "totalScripts": "323673",
+  "averageExecutionTime": "219.00577375537947",
+  "averageScriptExecutionTime": "209.91481692156066"
+}, {
+  "canonicalDomain": "*.shopify.com",
+  "totalExecutionTime": "234054570.88800171",
+  "totalOccurrences": "308417",
+  "totalScripts": "660398",
+  "averageExecutionTime": "758.8899797611723",
+  "averageScriptExecutionTime": "343.96350206501154"
+}, {
+  "canonicalDomain": "*.squarespace.com",
+  "totalExecutionTime": "860388114.06299865",
+  "totalOccurrences": "236228",
+  "totalScripts": "2128669",
+  "averageExecutionTime": "3642.1936182967265",
+  "averageScriptExecutionTime": "397.07597081030661"
+}, {
+  "canonicalDomain": "*.newrelic.com",
+  "totalExecutionTime": "61136192.837999888",
+  "totalOccurrences": "234387",
+  "totalScripts": "269301",
+  "averageExecutionTime": "260.83440138744885",
+  "averageScriptExecutionTime": "241.74506089114718"
+}, {
+  "canonicalDomain": "*.pubmatic.com",
+  "totalExecutionTime": "370370060.17999977",
+  "totalOccurrences": "221339",
+  "totalScripts": "3716082",
+  "averageExecutionTime": "1673.315864714305",
+  "averageScriptExecutionTime": "107.99056837240268"
+}, {
+  "canonicalDomain": "fonts.googleapis.com",
+  "totalExecutionTime": "25919.66699999999",
+  "totalOccurrences": "220602",
+  "totalScripts": "245366",
+  "averageExecutionTime": "0.11749515870209676",
+  "averageScriptExecutionTime": "0.095419799004541769"
+}, {
+  "canonicalDomain": "*.rubiconproject.com",
+  "totalExecutionTime": "219220182.77299944",
+  "totalOccurrences": "220488",
+  "totalScripts": "272629",
+  "averageExecutionTime": "994.24994908112774",
+  "averageScriptExecutionTime": "781.17623624573355"
+}, {
+  "canonicalDomain": "*.tiktok.com",
+  "totalExecutionTime": "98799146.953999832",
+  "totalOccurrences": "215993",
+  "totalScripts": "339216",
+  "averageExecutionTime": "457.41828186098581",
+  "averageScriptExecutionTime": "308.66202168536063"
+}, {
+  "canonicalDomain": "*.licdn.com",
+  "totalExecutionTime": "19550031.841999989",
+  "totalOccurrences": "187285",
+  "totalScripts": "192722",
+  "averageExecutionTime": "104.3865330485624",
+  "averageScriptExecutionTime": "94.621122912903559"
+}, {
+  "canonicalDomain": "*.adobedtm.com",
+  "totalExecutionTime": "34315040.799000032",
+  "totalOccurrences": "185022",
+  "totalScripts": "236890",
+  "averageExecutionTime": "185.46465176573594",
+  "averageScriptExecutionTime": "110.83793926725653"
+}, {
+  "canonicalDomain": "*.adnxs.com",
+  "totalExecutionTime": "3835345.2210000041",
+  "totalOccurrences": "177948",
+  "totalScripts": "281338",
+  "averageExecutionTime": "21.553179698563621",
+  "averageScriptExecutionTime": "13.995697673543951"
+}, {
+  "canonicalDomain": "*.amazon-adsystem.com",
+  "totalExecutionTime": "54193261.4589997",
+  "totalOccurrences": "177174",
+  "totalScripts": "366378",
+  "averageExecutionTime": "305.87592682334804",
+  "averageScriptExecutionTime": "154.31399716694992"
+}, {
+  "canonicalDomain": "*.yandex.st",
+  "totalExecutionTime": "296239283.05400056",
+  "totalOccurrences": "172717",
+  "totalScripts": "469600",
+  "averageExecutionTime": "1715.1715410411323",
+  "averageScriptExecutionTime": "652.05698067370849"
+}, {
+  "canonicalDomain": "*.cookiebot.com",
+  "totalExecutionTime": "52714357.144999847",
+  "totalOccurrences": "171303",
+  "totalScripts": "173001",
+  "averageExecutionTime": "307.72582584659892",
+  "averageScriptExecutionTime": "305.663344992985"
+}, {
+  "canonicalDomain": "*.criteo.com",
+  "totalExecutionTime": "19712989.433000021",
+  "totalOccurrences": "166940",
+  "totalScripts": "236655",
+  "averageExecutionTime": "118.08427838145444",
+  "averageScriptExecutionTime": "82.073439982804345"
+}, {
+  "canonicalDomain": "*.tynt.com",
+  "totalExecutionTime": "33579347.991999984",
+  "totalOccurrences": "162031",
+  "totalScripts": "269574",
+  "averageExecutionTime": "207.24026878807146",
+  "averageScriptExecutionTime": "126.61036189565529"
+}, {
+  "canonicalDomain": "*.blogblog.com",
+  "totalExecutionTime": "23285939.903",
+  "totalOccurrences": "153915",
+  "totalScripts": "215395",
+  "averageExecutionTime": "151.29090668875671",
+  "averageScriptExecutionTime": "84.331443775271183"
+}, {
+  "canonicalDomain": "*.hs-scripts.com",
+  "totalExecutionTime": "77390639.335999921",
+  "totalOccurrences": "147820",
+  "totalScripts": "444679",
+  "averageExecutionTime": "523.5464709511557",
+  "averageScriptExecutionTime": "186.02265854081992"
+}, {
+  "canonicalDomain": "*.33across.com",
+  "totalExecutionTime": "2443385.9450000003",
+  "totalOccurrences": "143025",
+  "totalScripts": "168213",
+  "averageExecutionTime": "17.083628351686741",
+  "averageScriptExecutionTime": "9.6478064005127369"
+}, {
+  "canonicalDomain": "*.klaviyo.com",
+  "totalExecutionTime": "89710597.23499997",
+  "totalOccurrences": "142926",
+  "totalScripts": "458494",
+  "averageExecutionTime": "627.671642913116",
+  "averageScriptExecutionTime": "161.60062161512388"
+}, {
+  "canonicalDomain": "*.vimeo.com",
+  "totalExecutionTime": "401820070.2790029",
+  "totalOccurrences": "141109",
+  "totalScripts": "520442",
+  "averageExecutionTime": "2847.5864068131973",
+  "averageScriptExecutionTime": "730.8553611197492"
+}, {
+  "canonicalDomain": "*.unpkg.com",
+  "totalExecutionTime": "135670279.47500023",
+  "totalOccurrences": "138968",
+  "totalScripts": "152461",
+  "averageExecutionTime": "976.26992886851588",
+  "averageScriptExecutionTime": "862.94586521964811"
+}, {
+  "canonicalDomain": "*.pinimg.com",
+  "totalExecutionTime": "18949520.025001366",
+  "totalOccurrences": "131401",
+  "totalScripts": "141643",
+  "averageExecutionTime": "144.21138366527941",
+  "averageScriptExecutionTime": "134.35455024243745"
+}, {
+  "canonicalDomain": "*.stripe.com",
+  "totalExecutionTime": "145090758.917",
+  "totalOccurrences": "127052",
+  "totalScripts": "461893",
+  "averageExecutionTime": "1141.9793385149378",
+  "averageScriptExecutionTime": "303.42231852127429"
+}, {
+  "canonicalDomain": "*.gumgum.com",
+  "totalExecutionTime": "3128068.5519999969",
+  "totalOccurrences": "123913",
+  "totalScripts": "552153",
+  "averageExecutionTime": "25.244070856165216",
+  "averageScriptExecutionTime": "7.0538576192253428"
+}, {
+  "canonicalDomain": "*.godaddy.com",
+  "totalExecutionTime": "114528394.69499996",
+  "totalOccurrences": "122066",
+  "totalScripts": "506130",
+  "averageExecutionTime": "938.24975582881268",
+  "averageScriptExecutionTime": "238.03471461301231"
+}, {
+  "canonicalDomain": "*.tribalfusion.com",
+  "totalExecutionTime": "69765.530999999988",
+  "totalOccurrences": "121668",
+  "totalScripts": "144832",
+  "averageExecutionTime": "0.57340903935299292",
+  "averageScriptExecutionTime": "0.4355559699574062"
+}, {
+  "canonicalDomain": "*.amazon.com",
+  "totalExecutionTime": "47748485.29600019",
+  "totalOccurrences": "120810",
+  "totalScripts": "160737",
+  "averageExecutionTime": "395.23619978478791",
+  "averageScriptExecutionTime": "265.64701429681043"
+}, {
+  "canonicalDomain": "*.onetrust.com",
+  "totalExecutionTime": "50534788.10799998",
+  "totalOccurrences": "114655",
+  "totalScripts": "222185",
+  "averageExecutionTime": "440.75520568662455",
+  "averageScriptExecutionTime": "229.35790210838496"
+}, {
+  "canonicalDomain": "*.tawk.to",
+  "totalExecutionTime": "40918655.252999909",
+  "totalOccurrences": "110838",
+  "totalScripts": "143585",
+  "averageExecutionTime": "369.17533023872579",
+  "averageScriptExecutionTime": "311.07141392729642"
+}, {
+  "canonicalDomain": "*.01net.com",
+  "totalExecutionTime": "23473240.809999973",
+  "totalOccurrences": "110013",
+  "totalScripts": "111841",
+  "averageExecutionTime": "213.36788206848274",
+  "averageScriptExecutionTime": "207.98992006373925"
+}, {
+  "canonicalDomain": "*.inmobi.com",
+  "totalExecutionTime": "21120359.657999955",
+  "totalOccurrences": "104461",
+  "totalScripts": "133358",
+  "averageExecutionTime": "202.18416115105128",
+  "averageScriptExecutionTime": "144.5980546192672"
+}, {
+  "canonicalDomain": "*.typekit.com",
+  "totalExecutionTime": "34926351.304",
+  "totalOccurrences": "102866",
+  "totalScripts": "104758",
+  "averageExecutionTime": "339.53251126708511",
+  "averageScriptExecutionTime": "331.28110304789431"
+}, {
+  "canonicalDomain": "*.pubmine.com",
+  "totalExecutionTime": "66936319.3289999",
+  "totalOccurrences": "102326",
+  "totalScripts": "434996",
+  "averageExecutionTime": "654.14771738365494",
+  "averageScriptExecutionTime": "194.94407023831974"
+}, {
+  "canonicalDomain": "*.iubenda.com",
+  "totalExecutionTime": "54801135.695999935",
+  "totalOccurrences": "93937",
+  "totalScripts": "174241",
+  "averageExecutionTime": "583.381795203167",
+  "averageScriptExecutionTime": "294.89047720288556"
+}, {
+  "canonicalDomain": "*.media.net",
+  "totalExecutionTime": "22747821.21400002",
+  "totalOccurrences": "93232",
+  "totalScripts": "135775",
+  "averageExecutionTime": "243.99156098764323",
+  "averageScriptExecutionTime": "181.6799141384123"
+}, {
+  "canonicalDomain": "*.getsentry.com",
+  "totalExecutionTime": "51909976.745000273",
+  "totalOccurrences": "89801",
+  "totalScripts": "93133",
+  "averageExecutionTime": "578.05566469193286",
+  "averageScriptExecutionTime": "538.81149041584729"
+}, {
+  "canonicalDomain": "*.sharethis.com",
+  "totalExecutionTime": "30497011.061000012",
+  "totalOccurrences": "88927",
+  "totalScripts": "214375",
+  "averageExecutionTime": "342.94433705173896",
+  "averageScriptExecutionTime": "116.08071841231261"
+}, {
+  "canonicalDomain": "*.ampproject.org",
+  "totalExecutionTime": "93306777.001999751",
+  "totalOccurrences": "88558",
+  "totalScripts": "209747",
+  "averageExecutionTime": "1053.6233542085372",
+  "averageScriptExecutionTime": "523.83811245905849"
+}, {
+  "canonicalDomain": "*.adform.net",
+  "totalExecutionTime": "1796668.9729999981",
+  "totalOccurrences": "86043",
+  "totalScripts": "88757",
+  "averageExecutionTime": "20.881059156468254",
+  "averageScriptExecutionTime": "14.06657606458649"
+}, {
+  "canonicalDomain": "*.redirectingat.com",
+  "totalExecutionTime": "26509021.742999971",
+  "totalOccurrences": "81338",
+  "totalScripts": "81650",
+  "averageExecutionTime": "325.91189533797171",
+  "averageScriptExecutionTime": "325.13497460801284"
+}, {
+  "canonicalDomain": "*.zdassets.com",
+  "totalExecutionTime": "110230961.3879993",
+  "totalOccurrences": "76298",
+  "totalScripts": "225347",
+  "averageExecutionTime": "1444.7424753990852",
+  "averageScriptExecutionTime": "476.07497731221866"
+}, {
+  "canonicalDomain": "*.crwdcntrl.net",
+  "totalExecutionTime": "9656336.1069999952",
+  "totalOccurrences": "70113",
+  "totalScripts": "101878",
+  "averageExecutionTime": "137.72533063768495",
+  "averageScriptExecutionTime": "95.3825183895996"
+}, {
+  "canonicalDomain": "*.tildacdn.com",
+  "totalExecutionTime": "92013253.143000141",
+  "totalOccurrences": "69944",
+  "totalScripts": "453275",
+  "averageExecutionTime": "1315.5274668735019",
+  "averageScriptExecutionTime": "177.11475536334962"
+}, {
+  "canonicalDomain": "*.brtstats.com",
+  "totalExecutionTime": "11251523.505999992",
+  "totalOccurrences": "68514",
+  "totalScripts": "79300",
+  "averageExecutionTime": "164.22225393350223",
+  "averageScriptExecutionTime": "121.4871363687228"
+}, {
+  "canonicalDomain": "*.ads-twitter.com",
+  "totalExecutionTime": "5356090.8330000006",
+  "totalOccurrences": "68128",
+  "totalScripts": "68326",
+  "averageExecutionTime": "78.618054735204311",
+  "averageScriptExecutionTime": "78.4014237464773"
+}, {
+  "canonicalDomain": "*.onesignal.com",
+  "totalExecutionTime": "16994756.030000009",
+  "totalOccurrences": "66991",
+  "totalScripts": "76428",
+  "averageExecutionTime": "253.68715245331447",
+  "averageScriptExecutionTime": "213.55428233916987"
+}, {
+  "canonicalDomain": "*.addtoany.com",
+  "totalExecutionTime": "9718289.8810000028",
+  "totalOccurrences": "66597",
+  "totalScripts": "78807",
+  "averageExecutionTime": "145.92684176464405",
+  "averageScriptExecutionTime": "122.06306243274241"
+}, {
+  "canonicalDomain": "*.editmysite.com",
+  "totalExecutionTime": "384978578.93300283",
+  "totalOccurrences": "66212",
+  "totalScripts": "553721",
+  "averageExecutionTime": "5814.3324311756569",
+  "averageScriptExecutionTime": "537.312691256804"
+}, {
+  "canonicalDomain": "id5-sync.com",
+  "totalExecutionTime": "15837825.911000038",
+  "totalOccurrences": "65666",
+  "totalScripts": "69397",
+  "averageExecutionTime": "241.18761476258643",
+  "averageScriptExecutionTime": "231.22730939146604"
+}, {
+  "canonicalDomain": "pixel.wp.com",
+  "totalExecutionTime": "3615359.0910000033",
+  "totalOccurrences": "64925",
+  "totalScripts": "65630",
+  "averageExecutionTime": "55.685161201386251",
+  "averageScriptExecutionTime": "54.922463563085664"
+}, {
+  "canonicalDomain": "*.deliverimp.com",
+  "totalExecutionTime": "4973528.3280000007",
+  "totalOccurrences": "64146",
+  "totalScripts": "69230",
+  "averageExecutionTime": "77.534504536525986",
+  "averageScriptExecutionTime": "72.817085910167108"
+}, {
+  "canonicalDomain": "*.daum.net",
+  "totalExecutionTime": "40904251.428999849",
+  "totalOccurrences": "63737",
+  "totalScripts": "247911",
+  "averageExecutionTime": "641.76618650077569",
+  "averageScriptExecutionTime": "185.58978507252283"
+}, {
+  "canonicalDomain": "d32hwlnfiv2gyn.cloudfront.net",
+  "totalExecutionTime": "8251389.3579999683",
+  "totalOccurrences": "59526",
+  "totalScripts": "59527",
+  "averageExecutionTime": "138.618240063165",
+  "averageScriptExecutionTime": "138.61685740684663"
+}, {
+  "canonicalDomain": "*.ctnsnet.com",
+  "totalExecutionTime": "41247.507999999987",
+  "totalOccurrences": "57806",
+  "totalScripts": "57838",
+  "averageExecutionTime": "0.71355063488219184",
+  "averageScriptExecutionTime": "0.64989421801658409"
+}, {
+  "canonicalDomain": "*.paypal.com",
+  "totalExecutionTime": "49906637.201000117",
+  "totalOccurrences": "56797",
+  "totalScripts": "180154",
+  "averageExecutionTime": "878.68438827755017",
+  "averageScriptExecutionTime": "319.7316748580011"
+}, {
+  "canonicalDomain": "*.iprom.net",
+  "totalExecutionTime": "106937.16499999985",
+  "totalOccurrences": "55739",
+  "totalScripts": "56304",
+  "averageExecutionTime": "1.9185339708283224",
+  "averageScriptExecutionTime": "0.872990831033072"
+}, {
+  "canonicalDomain": "*.jivosite.com",
+  "totalExecutionTime": "35383338.086999938",
+  "totalOccurrences": "55526",
+  "totalScripts": "81634",
+  "averageExecutionTime": "637.23909676547771",
+  "averageScriptExecutionTime": "389.69015435415855"
+}, {
+  "canonicalDomain": "*.sonobi.com",
+  "totalExecutionTime": "2738629.883",
+  "totalOccurrences": "54964",
+  "totalScripts": "54988",
+  "averageExecutionTime": "49.825883905829251",
+  "averageScriptExecutionTime": "49.820950212866691"
+}, {
+  "canonicalDomain": "yads.c.yimg.jp",
+  "totalExecutionTime": "30387424.784000129",
+  "totalOccurrences": "53919",
+  "totalScripts": "58953",
+  "averageExecutionTime": "563.57545177024986",
+  "averageScriptExecutionTime": "523.33402749237428"
+}, {
+  "canonicalDomain": "*.azurewebsites.net",
+  "totalExecutionTime": "37094581.512000851",
+  "totalOccurrences": "53458",
+  "totalScripts": "80476",
+  "averageExecutionTime": "693.90140880692991",
+  "averageScriptExecutionTime": "421.65247931992576"
+}, {
+  "canonicalDomain": "*.statcounter.com",
+  "totalExecutionTime": "5371363.8379999986",
+  "totalOccurrences": "51587",
+  "totalScripts": "52871",
+  "averageExecutionTime": "104.12243080621089",
+  "averageScriptExecutionTime": "90.7025568995634"
+}, {
+  "canonicalDomain": "*.im-apps.net",
+  "totalExecutionTime": "8028370.4700000025",
+  "totalOccurrences": "51541",
+  "totalScripts": "67920",
+  "averageExecutionTime": "155.76668031276066",
+  "averageScriptExecutionTime": "127.07290699540169"
+}, {
+  "canonicalDomain": "*.taboola.com",
+  "totalExecutionTime": "36404634.993999891",
+  "totalOccurrences": "50484",
+  "totalScripts": "92055",
+  "averageExecutionTime": "721.11233250138469",
+  "averageScriptExecutionTime": "332.79382366582922"
+}, {
+  "canonicalDomain": "*.snapchat.com",
+  "totalExecutionTime": "19609381.253999941",
+  "totalOccurrences": "49940",
+  "totalScripts": "56999",
+  "averageExecutionTime": "392.65881565878965",
+  "averageScriptExecutionTime": "356.11794067080393"
+}, {
+  "canonicalDomain": "*.accessibe.com",
+  "totalExecutionTime": "15225647.058999982",
+  "totalOccurrences": "48634",
+  "totalScripts": "48866",
+  "averageExecutionTime": "313.06590161204048",
+  "averageScriptExecutionTime": "311.89279357719539"
+}, {
+  "canonicalDomain": "*.adgear.com",
+  "totalExecutionTime": "27390.453999999994",
+  "totalOccurrences": "48485",
+  "totalScripts": "53891",
+  "averageExecutionTime": "0.56492634835516053",
+  "averageScriptExecutionTime": "0.51471508714035352"
+}, {
+  "canonicalDomain": "usercentrics.mgr.consensu.org",
+  "totalExecutionTime": "48633902.928999916",
+  "totalOccurrences": "47786",
+  "totalScripts": "102079",
+  "averageExecutionTime": "1017.743751914786",
+  "averageScriptExecutionTime": "489.49841088428883"
+}, {
+  "canonicalDomain": "*.chimpstatic.com",
+  "totalExecutionTime": "21990933.854999974",
+  "totalOccurrences": "47224",
+  "totalScripts": "84972",
+  "averageExecutionTime": "465.67283277570664",
+  "averageScriptExecutionTime": "266.18490200019318"
+}, {
+  "canonicalDomain": "*.scorecardresearch.com",
+  "totalExecutionTime": "4064761.7300000032",
+  "totalOccurrences": "46696",
+  "totalScripts": "46748",
+  "averageExecutionTime": "87.047321612129721",
+  "averageScriptExecutionTime": "86.824578868283041"
+}, {
+  "canonicalDomain": "*.dotomi.com",
+  "totalExecutionTime": "5167922.0700000022",
+  "totalOccurrences": "46153",
+  "totalScripts": "53175",
+  "averageExecutionTime": "111.97369770112448",
+  "averageScriptExecutionTime": "91.244510446774783"
+}, {
+  "canonicalDomain": "*.bing.com",
+  "totalExecutionTime": "7348576.5340000121",
+  "totalOccurrences": "45869",
+  "totalScripts": "51295",
+  "averageExecutionTime": "160.20790804246923",
+  "averageScriptExecutionTime": "128.6704835192138"
+}, {
+  "canonicalDomain": "*.trustpilot.com",
+  "totalExecutionTime": "10773752.038000017",
+  "totalOccurrences": "44934",
+  "totalScripts": "106945",
+  "averageExecutionTime": "239.76837223483341",
+  "averageScriptExecutionTime": "100.50145425634184"
+}, {
+  "canonicalDomain": "api-maps.yandex.ru",
+  "totalExecutionTime": "27735777.872000132",
+  "totalOccurrences": "44655",
+  "totalScripts": "57221",
+  "averageExecutionTime": "621.11248173777039",
+  "averageScriptExecutionTime": "380.82525069871315"
+}, {
+  "canonicalDomain": "*.st-hatena.com",
+  "totalExecutionTime": "86576088.613999739",
+  "totalOccurrences": "43308",
+  "totalScripts": "217483",
+  "averageExecutionTime": "1999.0784292509402",
+  "averageScriptExecutionTime": "281.67016725581931"
+}, {
+  "canonicalDomain": "*.loopme.biz",
+  "totalExecutionTime": "1415682.1410000038",
+  "totalOccurrences": "42797",
+  "totalScripts": "43382",
+  "averageExecutionTime": "33.07900415917014",
+  "averageScriptExecutionTime": "15.52692804557954"
+}, {
+  "canonicalDomain": "www.googleoptimize.com",
+  "totalExecutionTime": "6445359.6089999955",
+  "totalOccurrences": "41792",
+  "totalScripts": "42227",
+  "averageExecutionTime": "154.22472265026755",
+  "averageScriptExecutionTime": "152.91521870294142"
+}, {
+  "canonicalDomain": "*.cookie-script.com",
+  "totalExecutionTime": "9397496.0429999977",
+  "totalOccurrences": "41414",
+  "totalScripts": "41686",
+  "averageExecutionTime": "226.91592319022539",
+  "averageScriptExecutionTime": "223.88486903583328"
+}, {
+  "canonicalDomain": "sdk.privacy-center.org",
+  "totalExecutionTime": "29999364.846999932",
+  "totalOccurrences": "40288",
+  "totalScripts": "40796",
+  "averageExecutionTime": "744.62283675039441",
+  "averageScriptExecutionTime": "739.3121582687977"
+}, {
+  "canonicalDomain": "*.powr.io",
+  "totalExecutionTime": "189041945.434032",
+  "totalOccurrences": "39713",
+  "totalScripts": "56892",
+  "averageExecutionTime": "4760.203093043393",
+  "averageScriptExecutionTime": "3514.2479773720443"
+}, {
+  "canonicalDomain": "*.livechatinc.com",
+  "totalExecutionTime": "62604115.9239997",
+  "totalOccurrences": "39617",
+  "totalScripts": "183518",
+  "averageExecutionTime": "1580.23363515662",
+  "averageScriptExecutionTime": "307.78911207713708"
+}, {
+  "canonicalDomain": "*.bidswitch.net",
+  "totalExecutionTime": "8769.9279999999981",
+  "totalOccurrences": "39349",
+  "totalScripts": "39358",
+  "averageExecutionTime": "0.22287549874202636",
+  "averageScriptExecutionTime": "0.22285445627589023"
+}, {
+  "canonicalDomain": "*.uploads-ssl.webflow.com",
+  "totalExecutionTime": "132439054.58700003",
+  "totalOccurrences": "36763",
+  "totalScripts": "40942",
+  "averageExecutionTime": "3602.5094412044778",
+  "averageScriptExecutionTime": "3289.3413687924472"
+}, {
+  "canonicalDomain": "*.amplitude.com",
+  "totalExecutionTime": "7074149.4230000069",
+  "totalOccurrences": "36225",
+  "totalScripts": "39324",
+  "averageExecutionTime": "195.28362796411324",
+  "averageScriptExecutionTime": "179.48407556015661"
+}, {
+  "canonicalDomain": "*.casalemedia.com",
+  "totalExecutionTime": "3977130.4969999976",
+  "totalOccurrences": "33567",
+  "totalScripts": "41664",
+  "averageExecutionTime": "118.48334664998352",
+  "averageScriptExecutionTime": "101.83123660241694"
+}, {
+  "canonicalDomain": "hm.baidu.com",
+  "totalExecutionTime": "7571630.4209999936",
+  "totalOccurrences": "33318",
+  "totalScripts": "36970",
+  "averageExecutionTime": "227.25344921663955",
+  "averageScriptExecutionTime": "205.81673350726086"
+}, {
+  "canonicalDomain": "*.intercomcdn.com",
+  "totalExecutionTime": "36035427.9039997",
+  "totalOccurrences": "32751",
+  "totalScripts": "86720",
+  "averageExecutionTime": "1100.2848127996017",
+  "averageScriptExecutionTime": "407.21343318706045"
+}, {
+  "canonicalDomain": "*.akstat.io",
+  "totalExecutionTime": "3196311.9809999997",
+  "totalOccurrences": "32660",
+  "totalScripts": "34031",
+  "averageExecutionTime": "97.866257838334249",
+  "averageScriptExecutionTime": "94.745965110226692"
+}, {
+  "canonicalDomain": "*.hextom.com",
+  "totalExecutionTime": "11297970.82900002",
+  "totalOccurrences": "32051",
+  "totalScripts": "52039",
+  "averageExecutionTime": "352.499791862969",
+  "averageScriptExecutionTime": "205.71478960923153"
+}, {
+  "canonicalDomain": "*.bootstrapcdn.com",
+  "totalExecutionTime": "1724780.590999997",
+  "totalOccurrences": "31395",
+  "totalScripts": "32613",
+  "averageExecutionTime": "54.938066284440175",
+  "averageScriptExecutionTime": "53.260033521792238"
+}, {
+  "canonicalDomain": "*.adroll.com",
+  "totalExecutionTime": "10014556.071000015",
+  "totalOccurrences": "31186",
+  "totalScripts": "71992",
+  "averageExecutionTime": "321.12345510806097",
+  "averageScriptExecutionTime": "143.76952579459004"
+}, {
+  "canonicalDomain": "*.onetag-sys.com",
+  "totalExecutionTime": "1772331.9790000005",
+  "totalOccurrences": "29755",
+  "totalScripts": "43927",
+  "averageExecutionTime": "59.56417338262478",
+  "averageScriptExecutionTime": "36.471413387105812"
+}, {
+  "canonicalDomain": "*.callrail.com",
+  "totalExecutionTime": "7122348.536000005",
+  "totalOccurrences": "28866",
+  "totalScripts": "30743",
+  "averageExecutionTime": "246.73832661262404",
+  "averageScriptExecutionTime": "231.21106110591455"
+}, {
+  "canonicalDomain": "*.postrelease.com",
+  "totalExecutionTime": "8128.0850000000082",
+  "totalOccurrences": "28463",
+  "totalScripts": "28463",
+  "averageExecutionTime": "0.28556670062888673",
+  "averageScriptExecutionTime": "0.28556670062888673"
+}, {
+  "canonicalDomain": "*.judge.me",
+  "totalExecutionTime": "27416687.7819999",
+  "totalOccurrences": "28114",
+  "totalScripts": "70140",
+  "averageExecutionTime": "975.1969759550384",
+  "averageScriptExecutionTime": "431.09039949316252"
+}, {
+  "canonicalDomain": "*.aniview.com",
+  "totalExecutionTime": "15299055.798999988",
+  "totalOccurrences": "27530",
+  "totalScripts": "46021",
+  "averageExecutionTime": "555.723058445332",
+  "averageScriptExecutionTime": "317.15688277686928"
+}, {
+  "canonicalDomain": "*.segment.com",
+  "totalExecutionTime": "10054577.887999985",
+  "totalOccurrences": "27196",
+  "totalScripts": "66346",
+  "averageExecutionTime": "369.70796764230033",
+  "averageScriptExecutionTime": "142.3890678188898"
+}, {
+  "canonicalDomain": "*.recaptcha.net",
+  "totalExecutionTime": "8233568.780999992",
+  "totalOccurrences": "27115",
+  "totalScripts": "46439",
+  "averageExecutionTime": "303.65365225889695",
+  "averageScriptExecutionTime": "186.05582201788283"
+}, {
+  "canonicalDomain": "*.yotpo.com",
+  "totalExecutionTime": "17045110.055999931",
+  "totalOccurrences": "27061",
+  "totalScripts": "67988",
+  "averageExecutionTime": "629.877316285426",
+  "averageScriptExecutionTime": "237.93582084003339"
+}, {
+  "canonicalDomain": "*.wistia.com",
+  "totalExecutionTime": "85183417.5510007",
+  "totalOccurrences": "26714",
+  "totalScripts": "61005",
+  "averageExecutionTime": "3188.7181833870213",
+  "averageScriptExecutionTime": "1310.7409308768581"
+}, {
+  "canonicalDomain": "*.tidiochat.com",
+  "totalExecutionTime": "30004180.302999716",
+  "totalOccurrences": "25353",
+  "totalScripts": "47408",
+  "averageExecutionTime": "1183.4568020746956",
+  "averageScriptExecutionTime": "625.3173459978392"
+}, {
+  "canonicalDomain": "*.company-target.com",
+  "totalExecutionTime": "4372682.4620000012",
+  "totalOccurrences": "25122",
+  "totalScripts": "25641",
+  "averageExecutionTime": "174.05789594777463",
+  "averageScriptExecutionTime": "170.80932852347192"
+}, {
+  "canonicalDomain": "*.line-scdn.net",
+  "totalExecutionTime": "3510747.1059999927",
+  "totalOccurrences": "24995",
+  "totalScripts": "35309",
+  "averageExecutionTime": "140.45797583516716",
+  "averageScriptExecutionTime": "88.3363073016011"
+}, {
+  "canonicalDomain": "*.vk.com",
+  "totalExecutionTime": "74163046.755999833",
+  "totalOccurrences": "24569",
+  "totalScripts": "245133",
+  "averageExecutionTime": "3018.5618769994617",
+  "averageScriptExecutionTime": "262.56633119855866"
+}, {
+  "canonicalDomain": "*.bluelithium.com",
+  "totalExecutionTime": "2489175.2729999968",
+  "totalOccurrences": "22618",
+  "totalScripts": "24437",
+  "averageExecutionTime": "110.05284609602973",
+  "averageScriptExecutionTime": "70.871383676804371"
+}, {
+  "canonicalDomain": "*.technoratimedia.com",
+  "totalExecutionTime": "4310652.0489999978",
+  "totalOccurrences": "22378",
+  "totalScripts": "22496",
+  "averageExecutionTime": "192.62901282509574",
+  "averageScriptExecutionTime": "191.6712158369825"
+}, {
+  "canonicalDomain": "*.adingo.jp",
+  "totalExecutionTime": "7606413.7549999934",
+  "totalOccurrences": "22281",
+  "totalScripts": "35156",
+  "averageExecutionTime": "341.38565392037987",
+  "averageScriptExecutionTime": "201.63004381503777"
+}, {
+  "canonicalDomain": "*.smartsuppchat.com",
+  "totalExecutionTime": "8700467.389",
+  "totalOccurrences": "21642",
+  "totalScripts": "47773",
+  "averageExecutionTime": "402.01771504482008",
+  "averageScriptExecutionTime": "178.99730187598161"
+}, {
+  "canonicalDomain": "d335luupugsy2.cloudfront.net",
+  "totalExecutionTime": "6439927.0680000195",
+  "totalOccurrences": "21042",
+  "totalScripts": "41750",
+  "averageExecutionTime": "306.05109153122459",
+  "averageScriptExecutionTime": "149.876228500143"
+}, {
+  "canonicalDomain": "*.cetrk.com",
+  "totalExecutionTime": "9970199.3799999952",
+  "totalOccurrences": "20554",
+  "totalScripts": "34951",
+  "averageExecutionTime": "485.07343485452913",
+  "averageScriptExecutionTime": "292.60407548594424"
+}, {
+  "canonicalDomain": "*.mixpanel.com",
+  "totalExecutionTime": "3329698.5399999996",
+  "totalOccurrences": "20444",
+  "totalScripts": "20466",
+  "averageExecutionTime": "162.86923009195823",
+  "averageScriptExecutionTime": "162.15865238782337"
+}, {
+  "canonicalDomain": "*.bigcommerce.com",
+  "totalExecutionTime": "44603034.777000308",
+  "totalOccurrences": "19746",
+  "totalScripts": "75203",
+  "averageExecutionTime": "2258.8389940747652",
+  "averageScriptExecutionTime": "618.33076756604225"
+}, {
+  "canonicalDomain": "*.lijit.com",
+  "totalExecutionTime": "1195728.1719999991",
+  "totalOccurrences": "19707",
+  "totalScripts": "39965",
+  "averageExecutionTime": "60.675301770944223",
+  "averageScriptExecutionTime": "24.02224213445043"
+}, {
+  "canonicalDomain": "*.aspnetcdn.com",
+  "totalExecutionTime": "4421431.5190000068",
+  "totalOccurrences": "19679",
+  "totalScripts": "21378",
+  "averageExecutionTime": "224.67765226891635",
+  "averageScriptExecutionTime": "206.33865194284979"
+}, {
+  "canonicalDomain": "*.medium.com",
+  "totalExecutionTime": "237122405.48200953",
+  "totalOccurrences": "19673",
+  "totalScripts": "59961",
+  "averageExecutionTime": "12053.189929446917",
+  "averageScriptExecutionTime": "4012.8939861613903"
+}, {
+  "canonicalDomain": "*.privy.com",
+  "totalExecutionTime": "12292874.628999978",
+  "totalOccurrences": "19432",
+  "totalScripts": "30454",
+  "averageExecutionTime": "632.609851224782",
+  "averageScriptExecutionTime": "343.52467765275861"
+}, {
+  "canonicalDomain": "*.mapbox.com",
+  "totalExecutionTime": "12811494.407999955",
+  "totalOccurrences": "19307",
+  "totalScripts": "20718",
+  "averageExecutionTime": "663.56732832651119",
+  "averageScriptExecutionTime": "636.19553293895183"
+}, {
+  "canonicalDomain": "*.privacymanager.io",
+  "totalExecutionTime": "6401247.3759999964",
+  "totalOccurrences": "18856",
+  "totalScripts": "50387",
+  "averageExecutionTime": "339.4806627068308",
+  "averageScriptExecutionTime": "128.9016054195836"
+}, {
+  "canonicalDomain": "*.undertone.com",
+  "totalExecutionTime": "3003794.8699999987",
+  "totalOccurrences": "18824",
+  "totalScripts": "37458",
+  "averageExecutionTime": "159.57261315342117",
+  "averageScriptExecutionTime": "79.41227319290978"
+}, {
+  "canonicalDomain": "*.socdm.com",
+  "totalExecutionTime": "6860710.5619999943",
+  "totalOccurrences": "18113",
+  "totalScripts": "31052",
+  "averageExecutionTime": "378.77273571467964",
+  "averageScriptExecutionTime": "260.99221090035286"
+}, {
+  "canonicalDomain": "*.tumblr.com",
+  "totalExecutionTime": "49877013.994999953",
+  "totalOccurrences": "17786",
+  "totalScripts": "67979",
+  "averageExecutionTime": "2804.2850553806356",
+  "averageScriptExecutionTime": "711.197144756075"
+}, {
+  "canonicalDomain": "*.ctctcdn.com",
+  "totalExecutionTime": "601451.79700000072",
+  "totalOccurrences": "17757",
+  "totalScripts": "17837",
+  "averageExecutionTime": "33.871250605395062",
+  "averageScriptExecutionTime": "33.551828433857068"
+}, {
+  "canonicalDomain": "*.truffle.bid",
+  "totalExecutionTime": "18851.099999999882",
+  "totalOccurrences": "17580",
+  "totalScripts": "17580",
+  "averageExecutionTime": "1.0723037542662051",
+  "averageScriptExecutionTime": "1.0723037542662051"
+}, {
+  "canonicalDomain": "*.mailmunch.co",
+  "totalExecutionTime": "1153766.8149999997",
+  "totalOccurrences": "17494",
+  "totalScripts": "17654",
+  "averageExecutionTime": "65.952144449525548",
+  "averageScriptExecutionTime": "65.0618790918792"
+}, {
+  "canonicalDomain": "*.imrworldwide.com",
+  "totalExecutionTime": "6112580.5819999948",
+  "totalOccurrences": "17480",
+  "totalScripts": "49112",
+  "averageExecutionTime": "349.68996464530824",
+  "averageScriptExecutionTime": "126.29798031559871"
+}, {
+  "canonicalDomain": "*.smartlook.com",
+  "totalExecutionTime": "1742225.5110000004",
+  "totalOccurrences": "17274",
+  "totalScripts": "17891",
+  "averageExecutionTime": "100.85825581799237",
+  "averageScriptExecutionTime": "94.90543221025834"
+}, {
+  "canonicalDomain": "*.trustedshops.com",
+  "totalExecutionTime": "6446036.6379999975",
+  "totalOccurrences": "17188",
+  "totalScripts": "37467",
+  "averageExecutionTime": "375.03122166627833",
+  "averageScriptExecutionTime": "172.60945454774625"
+}, {
+  "canonicalDomain": "*.bizographics.com",
+  "totalExecutionTime": "5244486.350999997",
+  "totalOccurrences": "17126",
+  "totalScripts": "22638",
+  "averageExecutionTime": "306.22949614621029",
+  "averageScriptExecutionTime": "227.77731449974357"
+}, {
+  "canonicalDomain": "*.rambler.ru",
+  "totalExecutionTime": "68387479.397000685",
+  "totalOccurrences": "16907",
+  "totalScripts": "35877",
+  "averageExecutionTime": "4044.9210029573974",
+  "averageScriptExecutionTime": "1621.4481494058564"
+}, {
+  "canonicalDomain": "*.reddit.com",
+  "totalExecutionTime": "3875192.4489999926",
+  "totalOccurrences": "16277",
+  "totalScripts": "16578",
+  "averageExecutionTime": "238.07780604533957",
+  "averageScriptExecutionTime": "231.13955269214154"
+}, {
+  "canonicalDomain": "*.gemius.pl",
+  "totalExecutionTime": "2505319.2880000025",
+  "totalOccurrences": "16209",
+  "totalScripts": "20311",
+  "averageExecutionTime": "154.56347017089269",
+  "averageScriptExecutionTime": "121.1558823642706"
+}, {
+  "canonicalDomain": "*.adsrvr.org",
+  "totalExecutionTime": "1144276.0619999988",
+  "totalOccurrences": "15971",
+  "totalScripts": "33695",
+  "averageExecutionTime": "71.647114269613823",
+  "averageScriptExecutionTime": "37.45097706741889"
+}, {
+  "canonicalDomain": "*.optimizely.com",
+  "totalExecutionTime": "13464145.071999932",
+  "totalOccurrences": "15637",
+  "totalScripts": "18738",
+  "averageExecutionTime": "861.04400281383619",
+  "averageScriptExecutionTime": "770.38911439747233"
+}, {
+  "canonicalDomain": "*.microad.jp",
+  "totalExecutionTime": "7208106.894999994",
+  "totalOccurrences": "15515",
+  "totalScripts": "62984",
+  "averageExecutionTime": "464.58955172413704",
+  "averageScriptExecutionTime": "138.42156085672462"
+}, {
+  "canonicalDomain": "*.pixfs.net",
+  "totalExecutionTime": "10902780.293999987",
+  "totalOccurrences": "15388",
+  "totalScripts": "82787",
+  "averageExecutionTime": "708.52484364439817",
+  "averageScriptExecutionTime": "129.97362285709426"
+}, {
+  "canonicalDomain": "*.adsafeprotected.com",
+  "totalExecutionTime": "12542697.411999974",
+  "totalOccurrences": "15169",
+  "totalScripts": "27399",
+  "averageExecutionTime": "826.86382833410187",
+  "averageScriptExecutionTime": "277.209334812519"
+}, {
+  "canonicalDomain": "*.brandmetrics.com",
+  "totalExecutionTime": "1713041.2290000024",
+  "totalOccurrences": "14878",
+  "totalScripts": "14959",
+  "averageExecutionTime": "115.13921420889899",
+  "averageScriptExecutionTime": "114.6688843258503"
+}, {
+  "canonicalDomain": "*.trackcmp.net",
+  "totalExecutionTime": "1252559.1959999991",
+  "totalOccurrences": "14794",
+  "totalScripts": "15813",
+  "averageExecutionTime": "84.666702446937762",
+  "averageScriptExecutionTime": "68.06118127168655"
+}, {
+  "canonicalDomain": "*.herokuapp.com",
+  "totalExecutionTime": "15348264.599999959",
+  "totalOccurrences": "14652",
+  "totalScripts": "16971",
+  "averageExecutionTime": "1047.5201064701048",
+  "averageScriptExecutionTime": "999.14914330556746"
+}, {
+  "canonicalDomain": "*.href.asia",
+  "totalExecutionTime": "9887655.6099999286",
+  "totalOccurrences": "14541",
+  "totalScripts": "36220",
+  "averageExecutionTime": "679.9845684615866",
+  "averageScriptExecutionTime": "276.0658939507814"
+}, {
+  "canonicalDomain": "*.luckyorange.com",
+  "totalExecutionTime": "11646503.628999952",
+  "totalOccurrences": "14012",
+  "totalScripts": "27090",
+  "averageExecutionTime": "831.18067577790123",
+  "averageScriptExecutionTime": "367.7889521610997"
+}, {
+  "canonicalDomain": "*.tcdn.com.br",
+  "totalExecutionTime": "64191050.5190001",
+  "totalOccurrences": "13884",
+  "totalScripts": "50055",
+  "averageExecutionTime": "4623.3830682080079",
+  "averageScriptExecutionTime": "1080.6941397496553"
+}, {
+  "canonicalDomain": "*.branch.io",
+  "totalExecutionTime": "1245948.4350000005",
+  "totalOccurrences": "13768",
+  "totalScripts": "19339",
+  "averageExecutionTime": "90.495964192330135",
+  "averageScriptExecutionTime": "63.908692790044562"
+}, {
+  "canonicalDomain": "*.treasuredata.com",
+  "totalExecutionTime": "1292628.3399999978",
+  "totalOccurrences": "13594",
+  "totalScripts": "14084",
+  "averageExecutionTime": "95.0881521259379",
+  "averageScriptExecutionTime": "91.6914491589427"
+}, {
+  "canonicalDomain": "*.fullstory.com",
+  "totalExecutionTime": "9926682.9649999868",
+  "totalOccurrences": "13551",
+  "totalScripts": "14936",
+  "averageExecutionTime": "732.54246660762965",
+  "averageScriptExecutionTime": "633.21113069321791"
+}, {
+  "canonicalDomain": "*.snapwidget.com",
+  "totalExecutionTime": "2414692.2040000032",
+  "totalOccurrences": "13527",
+  "totalScripts": "23164",
+  "averageExecutionTime": "178.50907104309891",
+  "averageScriptExecutionTime": "87.974632093190451"
+}, {
+  "canonicalDomain": "*.stackadapt.com",
+  "totalExecutionTime": "1137725.5139999988",
+  "totalOccurrences": "13484",
+  "totalScripts": "13487",
+  "averageExecutionTime": "84.375965143874339",
+  "averageScriptExecutionTime": "84.3606990878079"
+}, {
+  "canonicalDomain": "*.bugsnag.com",
+  "totalExecutionTime": "5319036.42800006",
+  "totalOccurrences": "13395",
+  "totalScripts": "13448",
+  "averageExecutionTime": "397.091185367679",
+  "averageScriptExecutionTime": "390.910145315421"
+}, {
+  "canonicalDomain": "*.pendo.io",
+  "totalExecutionTime": "4757243.7249999959",
+  "totalOccurrences": "13336",
+  "totalScripts": "18901",
+  "averageExecutionTime": "356.72193498800124",
+  "averageScriptExecutionTime": "251.50264823285295"
+}, {
+  "canonicalDomain": "*.heapanalytics.com",
+  "totalExecutionTime": "4991118.5120000085",
+  "totalOccurrences": "13234",
+  "totalScripts": "15126",
+  "averageExecutionTime": "377.14360828169924",
+  "averageScriptExecutionTime": "277.82327319152779"
+}, {
+  "canonicalDomain": "*.brightcove.com",
+  "totalExecutionTime": "14382650.399000051",
+  "totalOccurrences": "13124",
+  "totalScripts": "14832",
+  "averageExecutionTime": "1095.9044802651667",
+  "averageScriptExecutionTime": "985.28063094264735"
+}, {
+  "canonicalDomain": "*.matomo.cloud",
+  "totalExecutionTime": "2529536.3709999952",
+  "totalOccurrences": "12943",
+  "totalScripts": "13373",
+  "averageExecutionTime": "195.43663532411327",
+  "averageScriptExecutionTime": "189.82572078214719"
+}, {
+  "canonicalDomain": "*.browser-update.org",
+  "totalExecutionTime": "500083.8080000077",
+  "totalOccurrences": "12856",
+  "totalScripts": "14128",
+  "averageExecutionTime": "38.898864965775338",
+  "averageScriptExecutionTime": "31.463309544182263"
+}, {
+  "canonicalDomain": "*.stamped.io",
+  "totalExecutionTime": "1692843.229000001",
+  "totalOccurrences": "12632",
+  "totalScripts": "12849",
+  "averageExecutionTime": "134.01228855288181",
+  "averageScriptExecutionTime": "130.67508604375845"
+}, {
+  "canonicalDomain": "*.mxptint.net",
+  "totalExecutionTime": "7291.8379999999961",
+  "totalOccurrences": "12319",
+  "totalScripts": "12319",
+  "averageExecutionTime": "0.5919180128257161",
+  "averageScriptExecutionTime": "0.5919180128257161"
+}, {
+  "canonicalDomain": "*.adkernel.com",
+  "totalExecutionTime": "15866.612999999992",
+  "totalOccurrences": "12242",
+  "totalScripts": "12292",
+  "averageExecutionTime": "1.2960801339650398",
+  "averageScriptExecutionTime": "1.2447697938789952"
+}, {
+  "canonicalDomain": "*.shappify-cdn.com",
+  "totalExecutionTime": "5184463.0279999888",
+  "totalOccurrences": "11926",
+  "totalScripts": "15099",
+  "averageExecutionTime": "434.71935502263915",
+  "averageScriptExecutionTime": "354.48281410084348"
+}, {
+  "canonicalDomain": "*.i-mobile.co.jp",
+  "totalExecutionTime": "2318966.5540000009",
+  "totalOccurrences": "11883",
+  "totalScripts": "19111",
+  "averageExecutionTime": "195.14992459816523",
+  "averageScriptExecutionTime": "122.33966763249704"
+}, {
+  "canonicalDomain": "*.sumo.com",
+  "totalExecutionTime": "16884811.977999937",
+  "totalOccurrences": "11786",
+  "totalScripts": "43199",
+  "averageExecutionTime": "1432.6159832004016",
+  "averageScriptExecutionTime": "389.07934872726975"
+}, {
+  "canonicalDomain": "*.outbrain.com",
+  "totalExecutionTime": "2480046.004999998",
+  "totalOccurrences": "11506",
+  "totalScripts": "17384",
+  "averageExecutionTime": "215.54371675647477",
+  "averageScriptExecutionTime": "120.3695540370859"
+}, {
+  "canonicalDomain": "cdn.doofinder.com",
+  "totalExecutionTime": "1540853.384999997",
+  "totalOccurrences": "11412",
+  "totalScripts": "14706",
+  "averageExecutionTime": "135.02045084121957",
+  "averageScriptExecutionTime": "116.7533024447948"
+}, {
+  "canonicalDomain": "*.getclicky.com",
+  "totalExecutionTime": "719336.5789999991",
+  "totalOccurrences": "11407",
+  "totalScripts": "11625",
+  "averageExecutionTime": "63.06097825896385",
+  "averageScriptExecutionTime": "61.733104760234959"
+}, {
+  "canonicalDomain": "*.lightwidget.com",
+  "totalExecutionTime": "2512824.631999997",
+  "totalOccurrences": "11137",
+  "totalScripts": "20425",
+  "averageExecutionTime": "225.62850246924668",
+  "averageScriptExecutionTime": "118.8057064291272"
+}, {
+  "canonicalDomain": "*.scdn.co",
+  "totalExecutionTime": "37778.304999999877",
+  "totalOccurrences": "11051",
+  "totalScripts": "15346",
+  "averageExecutionTime": "3.4185417609266016",
+  "averageScriptExecutionTime": "2.6156650879393295"
+}, {
+  "canonicalDomain": "*.bttrack.com",
+  "totalExecutionTime": "22219.487000000005",
+  "totalOccurrences": "10797",
+  "totalScripts": "10819",
+  "averageExecutionTime": "2.0579315550615953",
+  "averageScriptExecutionTime": "1.9327121515235708"
+}, {
+  "canonicalDomain": "*.optimonk.com",
+  "totalExecutionTime": "6365082.05299999",
+  "totalOccurrences": "10492",
+  "totalScripts": "35205",
+  "averageExecutionTime": "606.66050829203175",
+  "averageScriptExecutionTime": "170.88926553091846"
+}, {
+  "canonicalDomain": "*.embedly.com",
+  "totalExecutionTime": "14604628.402000006",
+  "totalOccurrences": "10428",
+  "totalScripts": "15766",
+  "averageExecutionTime": "1400.5205602224767",
+  "averageScriptExecutionTime": "980.37279506458583"
+}, {
+  "canonicalDomain": "*.simpli.fi",
+  "totalExecutionTime": "652690.60400000028",
+  "totalOccurrences": "10407",
+  "totalScripts": "10526",
+  "averageExecutionTime": "62.716498894974528",
+  "averageScriptExecutionTime": "61.9619086031838"
+}, {
+  "canonicalDomain": "*.cdninstagram.com",
+  "totalExecutionTime": "12875303.879000021",
+  "totalOccurrences": "10224",
+  "totalScripts": "89161",
+  "averageExecutionTime": "1259.3215844092322",
+  "averageScriptExecutionTime": "119.2463458277438"
+}, {
+  "canonicalDomain": "*.bidr.io",
+  "totalExecutionTime": "15870.928999999971",
+  "totalOccurrences": "10163",
+  "totalScripts": "17716",
+  "averageExecutionTime": "1.5616381973826639",
+  "averageScriptExecutionTime": "1.2638515804294763"
+}, {
+  "canonicalDomain": "*.mgid.com",
+  "totalExecutionTime": "18984111.279999934",
+  "totalOccurrences": "9908",
+  "totalScripts": "26614",
+  "averageExecutionTime": "1916.0386838917993",
+  "averageScriptExecutionTime": "659.85108239469514"
+}, {
+  "canonicalDomain": "23.62.3.183",
+  "totalExecutionTime": "3456935.8110000049",
+  "totalOccurrences": "9767",
+  "totalScripts": "15815",
+  "averageExecutionTime": "353.94039223917258",
+  "averageScriptExecutionTime": "177.00223976375372"
+}, {
+  "canonicalDomain": "*.mediavine.com",
+  "totalExecutionTime": "39908001.647999994",
+  "totalOccurrences": "9733",
+  "totalScripts": "95528",
+  "averageExecutionTime": "4100.2775760813684",
+  "averageScriptExecutionTime": "403.79414680592532"
+}, {
+  "canonicalDomain": "*.livejournal.com",
+  "totalExecutionTime": "55598359.055001035",
+  "totalOccurrences": "9526",
+  "totalScripts": "47044",
+  "averageExecutionTime": "5836.485309153989",
+  "averageScriptExecutionTime": "1190.2234986137235"
+}, {
+  "canonicalDomain": "*.fastly.net",
+  "totalExecutionTime": "15955115.025999904",
+  "totalOccurrences": "9459",
+  "totalScripts": "17107",
+  "averageExecutionTime": "1686.7655170736759",
+  "averageScriptExecutionTime": "1334.3367954089647"
+}, {
+  "canonicalDomain": "*.acuityplatform.com",
+  "totalExecutionTime": "3270.6729999999975",
+  "totalOccurrences": "9415",
+  "totalScripts": "9416",
+  "averageExecutionTime": "0.34738959107806661",
+  "averageScriptExecutionTime": "0.3413512480084972"
+}, {
+  "canonicalDomain": "*.quora.com",
+  "totalExecutionTime": "953165.95299999847",
+  "totalOccurrences": "9336",
+  "totalScripts": "17755",
+  "averageExecutionTime": "102.09575332047977",
+  "averageScriptExecutionTime": "53.50596548690168"
+}, {
+  "canonicalDomain": "*.imedia.cz",
+  "totalExecutionTime": "1459815.6199999982",
+  "totalOccurrences": "9262",
+  "totalScripts": "9327",
+  "averageExecutionTime": "157.61343338371836",
+  "averageScriptExecutionTime": "156.37568013567994"
+}, {
+  "canonicalDomain": "*.siteimprove.com",
+  "totalExecutionTime": "701294.36899999867",
+  "totalOccurrences": "9174",
+  "totalScripts": "9174",
+  "averageExecutionTime": "76.443685306300281",
+  "averageScriptExecutionTime": "76.443685306300281"
+}, {
+  "canonicalDomain": "*.attn.tv",
+  "totalExecutionTime": "4711166.4619999863",
+  "totalOccurrences": "9166",
+  "totalScripts": "24440",
+  "averageExecutionTime": "513.982812786384",
+  "averageScriptExecutionTime": "177.05699057152179"
+}, {
+  "canonicalDomain": "*.ubembed.com",
+  "totalExecutionTime": "2142393.6659999988",
+  "totalOccurrences": "9109",
+  "totalScripts": "13444",
+  "averageExecutionTime": "235.19526468328007",
+  "averageScriptExecutionTime": "161.85129857666576"
+}, {
+  "canonicalDomain": "*.yjtag.jp",
+  "totalExecutionTime": "2044309.3739999996",
+  "totalOccurrences": "9086",
+  "totalScripts": "9151",
+  "averageExecutionTime": "224.9955287255116",
+  "averageScriptExecutionTime": "221.37938662044149"
+}, {
+  "canonicalDomain": "*.aralego.com",
+  "totalExecutionTime": "1455806.3069999996",
+  "totalOccurrences": "8917",
+  "totalScripts": "8928",
+  "averageExecutionTime": "163.26189379836282",
+  "averageScriptExecutionTime": "163.13528412021984"
+}, {
+  "canonicalDomain": "an.yandex.ru",
+  "totalExecutionTime": "4054932.9559999891",
+  "totalOccurrences": "8817",
+  "totalScripts": "8914",
+  "averageExecutionTime": "459.89939389814964",
+  "averageScriptExecutionTime": "457.62219057880475"
+}, {
+  "canonicalDomain": "*.afterpay.com",
+  "totalExecutionTime": "1045570.3350000017",
+  "totalOccurrences": "8468",
+  "totalScripts": "8993",
+  "averageExecutionTime": "123.47311466698166",
+  "averageScriptExecutionTime": "109.02175317272872"
+}, {
+  "canonicalDomain": "*.voicestar.com",
+  "totalExecutionTime": "1343546.6859999972",
+  "totalOccurrences": "8400",
+  "totalScripts": "11375",
+  "averageExecutionTime": "159.94603404761887",
+  "averageScriptExecutionTime": "121.76901430555547"
+}, {
+  "canonicalDomain": "*.github.com",
+  "totalExecutionTime": "3813157.3310000366",
+  "totalOccurrences": "8349",
+  "totalScripts": "9255",
+  "averageExecutionTime": "456.72024565816696",
+  "averageScriptExecutionTime": "409.19931434678136"
+}, {
+  "canonicalDomain": "*.kxcdn.com",
+  "totalExecutionTime": "1925420.649000006",
+  "totalOccurrences": "8327",
+  "totalScripts": "10891",
+  "averageExecutionTime": "231.22620979944841",
+  "averageScriptExecutionTime": "137.43579590645155"
+}, {
+  "canonicalDomain": "*.klarna.com",
+  "totalExecutionTime": "1072726.0749999986",
+  "totalOccurrences": "8270",
+  "totalScripts": "9641",
+  "averageExecutionTime": "129.71294740024183",
+  "averageScriptExecutionTime": "88.7327257355903"
+}, {
+  "canonicalDomain": "*.vwo.com",
+  "totalExecutionTime": "5119936.2140000891",
+  "totalOccurrences": "8019",
+  "totalScripts": "16725",
+  "averageExecutionTime": "638.47564708817674",
+  "averageScriptExecutionTime": "318.19007058341236"
+}, {
+  "canonicalDomain": "*.trafficstars.com",
+  "totalExecutionTime": "2202826.2849999955",
+  "totalOccurrences": "7758",
+  "totalScripts": "21388",
+  "averageExecutionTime": "283.9425476927043",
+  "averageScriptExecutionTime": "95.945494364775783"
+}, {
+  "canonicalDomain": "*.trustarc.com",
+  "totalExecutionTime": "2181897.9160000007",
+  "totalOccurrences": "7395",
+  "totalScripts": "12697",
+  "averageExecutionTime": "295.0504281271127",
+  "averageScriptExecutionTime": "188.73648655193861"
+}, {
+  "canonicalDomain": "*.impact-ad.jp",
+  "totalExecutionTime": "1243022.2110000008",
+  "totalOccurrences": "7281",
+  "totalScripts": "8467",
+  "averageExecutionTime": "170.72135846724356",
+  "averageScriptExecutionTime": "99.501263453615223"
+}, {
+  "canonicalDomain": "*.qq.com",
+  "totalExecutionTime": "1847828.599000002",
+  "totalOccurrences": "7253",
+  "totalScripts": "8537",
+  "averageExecutionTime": "254.76748917689278",
+  "averageScriptExecutionTime": "203.94528020154854"
+}, {
+  "canonicalDomain": "*.unrulymedia.com",
+  "totalExecutionTime": "1463.7569999999992",
+  "totalOccurrences": "6983",
+  "totalScripts": "6987",
+  "averageExecutionTime": "0.20961721323213539",
+  "averageScriptExecutionTime": "0.20951031075468982"
+}, {
+  "canonicalDomain": "*.teads.tv",
+  "totalExecutionTime": "2289202.0600000103",
+  "totalOccurrences": "6909",
+  "totalScripts": "10697",
+  "averageExecutionTime": "331.33623679259074",
+  "averageScriptExecutionTime": "198.07870726588641"
+}, {
+  "canonicalDomain": "*.freshchat.com",
+  "totalExecutionTime": "20593791.182999805",
+  "totalOccurrences": "6741",
+  "totalScripts": "56628",
+  "averageExecutionTime": "3055.0053676012271",
+  "averageScriptExecutionTime": "348.93653289834384"
+}, {
+  "canonicalDomain": "*.olark.com",
+  "totalExecutionTime": "8896143.2429999691",
+  "totalOccurrences": "6739",
+  "totalScripts": "27000",
+  "averageExecutionTime": "1320.0984186080966",
+  "averageScriptExecutionTime": "278.65875944911022"
+}, {
+  "canonicalDomain": "*.chartbeat.com",
+  "totalExecutionTime": "1376622.4849999954",
+  "totalOccurrences": "6715",
+  "totalScripts": "8225",
+  "averageExecutionTime": "205.00707148175658",
+  "averageScriptExecutionTime": "169.71190270538577"
+}, {
+  "canonicalDomain": "payments.amazon.com",
+  "totalExecutionTime": "1077707.5839999975",
+  "totalOccurrences": "6678",
+  "totalScripts": "6824",
+  "averageExecutionTime": "161.38178855944852",
+  "averageScriptExecutionTime": "155.00609184386514"
+}, {
+  "canonicalDomain": "*.viglink.com",
+  "totalExecutionTime": "4145607.6249999413",
+  "totalOccurrences": "6675",
+  "totalScripts": "7545",
+  "averageExecutionTime": "621.06481273407326",
+  "averageScriptExecutionTime": "559.06358714106466"
+}, {
+  "canonicalDomain": "*.affirm.com",
+  "totalExecutionTime": "3293989.7879999946",
+  "totalOccurrences": "6594",
+  "totalScripts": "6662",
+  "averageExecutionTime": "499.54349226569497",
+  "averageScriptExecutionTime": "493.61821506178609"
+}, {
+  "canonicalDomain": "*.civiccomputing.com",
+  "totalExecutionTime": "2295560.5489999959",
+  "totalOccurrences": "6533",
+  "totalScripts": "6589",
+  "averageExecutionTime": "351.37923603245008",
+  "averageScriptExecutionTime": "348.69120350528084"
+}, {
+  "canonicalDomain": "*.responsivevoice.org",
+  "totalExecutionTime": "777444.89399999869",
+  "totalOccurrences": "6401",
+  "totalScripts": "6453",
+  "averageExecutionTime": "121.45678706452136",
+  "averageScriptExecutionTime": "120.02792209550594"
+}, {
+  "canonicalDomain": "*.plausible.io",
+  "totalExecutionTime": "1192010.7189999989",
+  "totalOccurrences": "6317",
+  "totalScripts": "6319",
+  "averageExecutionTime": "188.69886322621491",
+  "averageScriptExecutionTime": "188.68124679436434"
+}, {
+  "canonicalDomain": "*.jwpcdn.com",
+  "totalExecutionTime": "4769419.3840001123",
+  "totalOccurrences": "6165",
+  "totalScripts": "13150",
+  "averageExecutionTime": "773.62844833740712",
+  "averageScriptExecutionTime": "266.85800502694246"
+}, {
+  "canonicalDomain": "*.parsely.com",
+  "totalExecutionTime": "1372516.2839999986",
+  "totalOccurrences": "6157",
+  "totalScripts": "6181",
+  "averageExecutionTime": "222.9196498294618",
+  "averageScriptExecutionTime": "222.26853264576863"
+}, {
+  "canonicalDomain": "*.sndcdn.com",
+  "totalExecutionTime": "14954562.488000046",
+  "totalOccurrences": "6038",
+  "totalScripts": "18909",
+  "averageExecutionTime": "2476.7410546538649",
+  "averageScriptExecutionTime": "785.664851056208"
+}, {
+  "canonicalDomain": "*.bluecava.com",
+  "totalExecutionTime": "457421.54600000003",
+  "totalOccurrences": "5973",
+  "totalScripts": "6080",
+  "averageExecutionTime": "76.581541269044",
+  "averageScriptExecutionTime": "75.322686673363577"
+}, {
+  "canonicalDomain": "*.infolinks.com",
+  "totalExecutionTime": "10598013.882999992",
+  "totalOccurrences": "5954",
+  "totalScripts": "40731",
+  "averageExecutionTime": "1779.9821771918027",
+  "averageScriptExecutionTime": "227.6302182105191"
+}, {
+  "canonicalDomain": "*.iperceptions.com",
+  "totalExecutionTime": "788233.114",
+  "totalOccurrences": "5939",
+  "totalScripts": "10275",
+  "averageExecutionTime": "132.72152113150358",
+  "averageScriptExecutionTime": "76.660635696245052"
+}, {
+  "canonicalDomain": "*.qualtrics.com",
+  "totalExecutionTime": "1069845.9889999991",
+  "totalOccurrences": "5922",
+  "totalScripts": "8295",
+  "averageExecutionTime": "180.65619537318449",
+  "averageScriptExecutionTime": "113.43971480395918"
+}, {
+  "canonicalDomain": "*.dtscout.com",
+  "totalExecutionTime": "469835.6650000001",
+  "totalOccurrences": "5825",
+  "totalScripts": "5952",
+  "averageExecutionTime": "80.658483261802559",
+  "averageScriptExecutionTime": "77.934854363376147"
+}, {
+  "canonicalDomain": "*.drift.com",
+  "totalExecutionTime": "25181423.181999926",
+  "totalOccurrences": "5811",
+  "totalScripts": "73410",
+  "averageExecutionTime": "4333.4061576320682",
+  "averageScriptExecutionTime": "328.39971633617961"
+}, {
+  "canonicalDomain": "*.forter.com",
+  "totalExecutionTime": "5257239.6499999668",
+  "totalOccurrences": "5741",
+  "totalScripts": "5743",
+  "averageExecutionTime": "915.73587354118831",
+  "averageScriptExecutionTime": "915.25802447308172"
+}, {
+  "canonicalDomain": "*.serving-sys.com",
+  "totalExecutionTime": "9059999.0350030847",
+  "totalOccurrences": "5738",
+  "totalScripts": "6739",
+  "averageExecutionTime": "1578.9472002445229",
+  "averageScriptExecutionTime": "1484.9595743933285"
+}, {
+  "canonicalDomain": "*.erne.co",
+  "totalExecutionTime": "350740.70200000005",
+  "totalOccurrences": "5708",
+  "totalScripts": "5797",
+  "averageExecutionTime": "61.4472147862649",
+  "averageScriptExecutionTime": "60.118439719107727"
+}, {
+  "canonicalDomain": "*.pagesense.io",
+  "totalExecutionTime": "1687003.2309999978",
+  "totalOccurrences": "5672",
+  "totalScripts": "5940",
+  "averageExecutionTime": "297.42652168547227",
+  "averageScriptExecutionTime": "287.08126721908826"
+}, {
+  "canonicalDomain": "*.etracker.com",
+  "totalExecutionTime": "1516698.0179999976",
+  "totalOccurrences": "5611",
+  "totalScripts": "7513",
+  "averageExecutionTime": "270.30796970237031",
+  "averageScriptExecutionTime": "195.43344124211748"
+}, {
+  "canonicalDomain": "*.readspeaker.com",
+  "totalExecutionTime": "595573.39399999927",
+  "totalOccurrences": "5558",
+  "totalScripts": "5899",
+  "averageExecutionTime": "107.15606225260878",
+  "averageScriptExecutionTime": "95.813101865179377"
+}, {
+  "canonicalDomain": "*.ecwid.com",
+  "totalExecutionTime": "4823195.8439999744",
+  "totalOccurrences": "5538",
+  "totalScripts": "8255",
+  "averageExecutionTime": "870.92738244853263",
+  "averageScriptExecutionTime": "654.87532451847324"
+}, {
+  "canonicalDomain": "*.dailymotion.com",
+  "totalExecutionTime": "47308996.425999761",
+  "totalOccurrences": "5447",
+  "totalScripts": "76443",
+  "averageExecutionTime": "8685.33071892781",
+  "averageScriptExecutionTime": "576.58189298096511"
+}, {
+  "canonicalDomain": "*.inspectlet.com",
+  "totalExecutionTime": "7841191.703",
+  "totalOccurrences": "5338",
+  "totalScripts": "5344",
+  "averageExecutionTime": "1468.9381234544774",
+  "averageScriptExecutionTime": "1468.701529130758"
+}, {
+  "canonicalDomain": "*.mouseflow.com",
+  "totalExecutionTime": "240861.90899999975",
+  "totalOccurrences": "4985",
+  "totalScripts": "4989",
+  "averageExecutionTime": "48.317333801404239",
+  "averageScriptExecutionTime": "48.28482918756275"
+}, {
+  "canonicalDomain": "*.yieldmanager.com",
+  "totalExecutionTime": "14477677.745",
+  "totalOccurrences": "4938",
+  "totalScripts": "12595",
+  "averageExecutionTime": "2931.8909973673608",
+  "averageScriptExecutionTime": "1021.6660737309298"
+}, {
+  "canonicalDomain": "*.mywebsitebuilder.com",
+  "totalExecutionTime": "21118574.797000539",
+  "totalOccurrences": "4817",
+  "totalScripts": "7059",
+  "averageExecutionTime": "4384.1757934400048",
+  "averageScriptExecutionTime": "3354.9624521647484"
+}, {
+  "canonicalDomain": "*.doubleverify.com",
+  "totalExecutionTime": "5550672.1290000062",
+  "totalOccurrences": "4740",
+  "totalScripts": "11744",
+  "averageExecutionTime": "1171.0278753164539",
+  "averageScriptExecutionTime": "379.2176057664384"
+}, {
+  "canonicalDomain": "*.dwin1.com",
+  "totalExecutionTime": "431196.26699999959",
+  "totalOccurrences": "4621",
+  "totalScripts": "4644",
+  "averageExecutionTime": "93.312327851114389",
+  "averageScriptExecutionTime": "92.9449439515256"
+}, {
+  "canonicalDomain": "*.adriver.ru",
+  "totalExecutionTime": "791152.31300000136",
+  "totalOccurrences": "4615",
+  "totalScripts": "5704",
+  "averageExecutionTime": "171.43062036836423",
+  "averageScriptExecutionTime": "142.11212122692748"
+}, {
+  "canonicalDomain": "*.force.com",
+  "totalExecutionTime": "958092.27899999928",
+  "totalOccurrences": "4573",
+  "totalScripts": "7696",
+  "averageExecutionTime": "209.51066673955836",
+  "averageScriptExecutionTime": "126.5281903491509"
+}, {
+  "canonicalDomain": "*.xiti.com",
+  "totalExecutionTime": "465330.96200000047",
+  "totalOccurrences": "4514",
+  "totalScripts": "4536",
+  "averageExecutionTime": "103.08616792202039",
+  "averageScriptExecutionTime": "102.65810245901646"
+}, {
+  "canonicalDomain": "djtflbt20bdde.cloudfront.net",
+  "totalExecutionTime": "622096.18599999847",
+  "totalOccurrences": "4484",
+  "totalScripts": "4981",
+  "averageExecutionTime": "138.73688358608362",
+  "averageScriptExecutionTime": "112.58371665923266"
+}, {
+  "canonicalDomain": "*.micpn.com",
+  "totalExecutionTime": "363501.66600000073",
+  "totalOccurrences": "4465",
+  "totalScripts": "4465",
+  "averageExecutionTime": "81.411347368421175",
+  "averageScriptExecutionTime": "81.411347368421175"
+}, {
+  "canonicalDomain": "*.adlightning.com",
+  "totalExecutionTime": "7161176.8000000007",
+  "totalOccurrences": "4424",
+  "totalScripts": "13246",
+  "averageExecutionTime": "1618.7108499095846",
+  "averageScriptExecutionTime": "537.04713032431266"
+}, {
+  "canonicalDomain": "*.adsco.re",
+  "totalExecutionTime": "3374026.0469999989",
+  "totalOccurrences": "4378",
+  "totalScripts": "4388",
+  "averageExecutionTime": "770.67748903608924",
+  "averageScriptExecutionTime": "768.64358622658665"
+}, {
+  "canonicalDomain": "*.createjs.com",
+  "totalExecutionTime": "12852086.660000015",
+  "totalOccurrences": "4377",
+  "totalScripts": "4524",
+  "averageExecutionTime": "2936.2775097098483",
+  "averageScriptExecutionTime": "2870.3944818939913"
+}, {
+  "canonicalDomain": "*.socialshopwave.com",
+  "totalExecutionTime": "6469006.9009999754",
+  "totalOccurrences": "4310",
+  "totalScripts": "18366",
+  "averageExecutionTime": "1500.9296754060279",
+  "averageScriptExecutionTime": "345.78991444463514"
+}, {
+  "canonicalDomain": "*.adyoulike.com",
+  "totalExecutionTime": "171369.32399999988",
+  "totalOccurrences": "4235",
+  "totalScripts": "6502",
+  "averageExecutionTime": "40.4650115702479",
+  "averageScriptExecutionTime": "13.365379796806639"
+}, {
+  "canonicalDomain": "*.loyaltylion.com",
+  "totalExecutionTime": "3434456.3809999893",
+  "totalOccurrences": "4213",
+  "totalScripts": "13037",
+  "averageExecutionTime": "815.20445786850132",
+  "averageScriptExecutionTime": "218.67399576650453"
+}, {
+  "canonicalDomain": "*.opentable.com",
+  "totalExecutionTime": "329711.5560000001",
+  "totalOccurrences": "4209",
+  "totalScripts": "5610",
+  "averageExecutionTime": "78.3348909479686",
+  "averageScriptExecutionTime": "43.35470202915"
+}, {
+  "canonicalDomain": "*.convertexperiments.com",
+  "totalExecutionTime": "2179675.093000012",
+  "totalOccurrences": "4173",
+  "totalScripts": "4182",
+  "averageExecutionTime": "522.32808363288132",
+  "averageScriptExecutionTime": "520.64566403067647"
+}, {
+  "canonicalDomain": "*.impactradius-event.com",
+  "totalExecutionTime": "526186.03999999934",
+  "totalOccurrences": "4158",
+  "totalScripts": "4178",
+  "averageExecutionTime": "126.5478691678691",
+  "averageScriptExecutionTime": "126.00878342953348"
+}, {
+  "canonicalDomain": "*.reviews.io",
+  "totalExecutionTime": "1559711.6339999959",
+  "totalOccurrences": "4151",
+  "totalScripts": "7279",
+  "averageExecutionTime": "375.74358805107113",
+  "averageScriptExecutionTime": "204.95985532453926"
+}, {
+  "canonicalDomain": "*.clearbitjs.com",
+  "totalExecutionTime": "921841.20799999987",
+  "totalOccurrences": "4136",
+  "totalScripts": "4881",
+  "averageExecutionTime": "222.882303675048",
+  "averageScriptExecutionTime": "193.76242734526105"
+}, {
+  "canonicalDomain": "*.sojern.com",
+  "totalExecutionTime": "1943515.9739999997",
+  "totalOccurrences": "4030",
+  "totalScripts": "6287",
+  "averageExecutionTime": "482.26202828784159",
+  "averageScriptExecutionTime": "292.61919426799017"
+}, {
+  "canonicalDomain": "*.hotmart.com",
+  "totalExecutionTime": "11429425.555000169",
+  "totalOccurrences": "4013",
+  "totalScripts": "15134",
+  "averageExecutionTime": "2848.100063543528",
+  "averageScriptExecutionTime": "724.21308555803921"
+}, {
+  "canonicalDomain": "*.calendly.com",
+  "totalExecutionTime": "6561749.2240000013",
+  "totalOccurrences": "4007",
+  "totalScripts": "11075",
+  "averageExecutionTime": "1637.5715557773888",
+  "averageScriptExecutionTime": "584.4309100687077"
+}, {
+  "canonicalDomain": "*.cquotient.com",
+  "totalExecutionTime": "1490201.7719999976",
+  "totalOccurrences": "4001",
+  "totalScripts": "4516",
+  "averageExecutionTime": "372.45732866783226",
+  "averageScriptExecutionTime": "321.96521708322854"
+}, {
+  "canonicalDomain": "*.moatads.com",
+  "totalExecutionTime": "4077241.7839999944",
+  "totalOccurrences": "3871",
+  "totalScripts": "5286",
+  "averageExecutionTime": "1053.2786835443007",
+  "averageScriptExecutionTime": "804.21654582794963"
+}, {
+  "canonicalDomain": "*.fortawesome.com",
+  "totalExecutionTime": "1314613.2679999934",
+  "totalOccurrences": "3781",
+  "totalScripts": "4161",
+  "averageExecutionTime": "347.68930653266193",
+  "averageScriptExecutionTime": "301.76744720091523"
+}, {
+  "canonicalDomain": "*.cxense.com",
+  "totalExecutionTime": "1990036.031999995",
+  "totalOccurrences": "3731",
+  "totalScripts": "5842",
+  "averageExecutionTime": "533.37872741892238",
+  "averageScriptExecutionTime": "382.21820092891932"
+}, {
+  "canonicalDomain": "d1m6l9dfulcyw7.cloudfront.net",
+  "totalExecutionTime": "3231276.3199999295",
+  "totalOccurrences": "3549",
+  "totalScripts": "3615",
+  "averageExecutionTime": "910.47515356436429",
+  "averageScriptExecutionTime": "898.52909171595707"
+}, {
+  "canonicalDomain": "*.arcgis.com",
+  "totalExecutionTime": "19823703.239000384",
+  "totalOccurrences": "3478",
+  "totalScripts": "22331",
+  "averageExecutionTime": "5699.7421618747485",
+  "averageScriptExecutionTime": "914.698191421376"
+}, {
+  "canonicalDomain": "*.ruxit.com",
+  "totalExecutionTime": "3834502.0119999787",
+  "totalOccurrences": "3420",
+  "totalScripts": "3440",
+  "averageExecutionTime": "1121.1994187134442",
+  "averageScriptExecutionTime": "1114.8523277777745"
+}, {
+  "canonicalDomain": "*.appdynamics.com",
+  "totalExecutionTime": "3100341.4409999973",
+  "totalOccurrences": "3419",
+  "totalScripts": "5889",
+  "averageExecutionTime": "906.797730622988",
+  "averageScriptExecutionTime": "505.2471689090371"
+}, {
+  "canonicalDomain": "*.abtasty.com",
+  "totalExecutionTime": "1654557.8759999983",
+  "totalOccurrences": "3343",
+  "totalScripts": "5319",
+  "averageExecutionTime": "494.93205982650232",
+  "averageScriptExecutionTime": "319.18175716422286"
+}, {
+  "canonicalDomain": "*.survicate.com",
+  "totalExecutionTime": "1166190.7559999987",
+  "totalOccurrences": "3308",
+  "totalScripts": "4105",
+  "averageExecutionTime": "352.5365042321643",
+  "averageScriptExecutionTime": "300.392290961306"
+}, {
+  "canonicalDomain": "*.fonts.com",
+  "totalExecutionTime": "731259.75900000462",
+  "totalOccurrences": "3295",
+  "totalScripts": "3484",
+  "averageExecutionTime": "221.9301241274672",
+  "averageScriptExecutionTime": "200.87077933738155"
+}, {
+  "canonicalDomain": "*.3lift.com",
+  "totalExecutionTime": "6094.5439999999971",
+  "totalOccurrences": "3269",
+  "totalScripts": "3354",
+  "averageExecutionTime": "1.8643450596512678",
+  "averageScriptExecutionTime": "1.8129938819210758"
+}, {
+  "canonicalDomain": "*.bazaarvoice.com",
+  "totalExecutionTime": "1414340.0379999988",
+  "totalOccurrences": "3262",
+  "totalScripts": "8555",
+  "averageExecutionTime": "433.580637032495",
+  "averageScriptExecutionTime": "147.00392029924126"
+}, {
+  "canonicalDomain": "*.purechat.com",
+  "totalExecutionTime": "1077541.4829999974",
+  "totalOccurrences": "3261",
+  "totalScripts": "3297",
+  "averageExecutionTime": "330.43283747316769",
+  "averageScriptExecutionTime": "325.67724302361154"
+}, {
+  "canonicalDomain": "*.rakuten-static.com",
+  "totalExecutionTime": "411577.75899999996",
+  "totalOccurrences": "3206",
+  "totalScripts": "3271",
+  "averageExecutionTime": "128.37734217092915",
+  "averageScriptExecutionTime": "124.83596759795614"
+}, {
+  "canonicalDomain": "*.okta.com",
+  "totalExecutionTime": "385561.55099999986",
+  "totalOccurrences": "3162",
+  "totalScripts": "3193",
+  "averageExecutionTime": "121.93597438330171",
+  "averageScriptExecutionTime": "118.44836198081387"
+}, {
+  "canonicalDomain": "*.highcharts.com",
+  "totalExecutionTime": "666442.97800000058",
+  "totalOccurrences": "3106",
+  "totalScripts": "3764",
+  "averageExecutionTime": "214.56631616226684",
+  "averageScriptExecutionTime": "168.72191372420519"
+}, {
+  "canonicalDomain": "*.getsitecontrol.com",
+  "totalExecutionTime": "1455994.1499999966",
+  "totalOccurrences": "3062",
+  "totalScripts": "3877",
+  "averageExecutionTime": "475.50429457870524",
+  "averageScriptExecutionTime": "421.19958033964576"
+}, {
+  "canonicalDomain": "*.ensighten.com",
+  "totalExecutionTime": "1654055.5779999946",
+  "totalOccurrences": "3033",
+  "totalScripts": "4445",
+  "averageExecutionTime": "545.35297659083119",
+  "averageScriptExecutionTime": "352.03314416968755"
+}, {
+  "canonicalDomain": "*.flashtalking.com",
+  "totalExecutionTime": "503975.63699999976",
+  "totalOccurrences": "2983",
+  "totalScripts": "3827",
+  "averageExecutionTime": "168.94925812939991",
+  "averageScriptExecutionTime": "92.302387453373228"
+}, {
+  "canonicalDomain": "*.bitly.com",
+  "totalExecutionTime": "471174.82399999892",
+  "totalOccurrences": "2979",
+  "totalScripts": "2983",
+  "averageExecutionTime": "158.16543269553497",
+  "averageScriptExecutionTime": "157.96552786169798"
+}, {
+  "canonicalDomain": "*.online-metrix.net",
+  "totalExecutionTime": "1777640.4169999992",
+  "totalOccurrences": "2935",
+  "totalScripts": "5001",
+  "averageExecutionTime": "605.66964804088525",
+  "averageScriptExecutionTime": "164.81207094426864"
+}, {
+  "canonicalDomain": "*.liveperson.com",
+  "totalExecutionTime": "1929662.4649999987",
+  "totalOccurrences": "2797",
+  "totalScripts": "13473",
+  "averageExecutionTime": "689.904349302825",
+  "averageScriptExecutionTime": "140.64112371607465"
+}, {
+  "canonicalDomain": "*.avis-verifies.com",
+  "totalExecutionTime": "1242313.515999994",
+  "totalOccurrences": "2785",
+  "totalScripts": "4986",
+  "averageExecutionTime": "446.07307576301378",
+  "averageScriptExecutionTime": "305.61279050354625"
+}, {
+  "canonicalDomain": "*.issuu.com",
+  "totalExecutionTime": "5268133.0700000953",
+  "totalOccurrences": "2692",
+  "totalScripts": "6054",
+  "averageExecutionTime": "1956.9587927192044",
+  "averageScriptExecutionTime": "832.75765551484142"
+}, {
+  "canonicalDomain": "*.bugherd.com",
+  "totalExecutionTime": "370607.63799999945",
+  "totalOccurrences": "2677",
+  "totalScripts": "4105",
+  "averageExecutionTime": "138.44140381023536",
+  "averageScriptExecutionTime": "71.459444564811434"
+}, {
+  "canonicalDomain": "*.evergage.com",
+  "totalExecutionTime": "1029352.025",
+  "totalOccurrences": "2658",
+  "totalScripts": "2659",
+  "averageExecutionTime": "387.26562264860763",
+  "averageScriptExecutionTime": "386.63712170805087"
+}, {
+  "canonicalDomain": "*.rfihub.com",
+  "totalExecutionTime": "259497.40300000034",
+  "totalOccurrences": "2610",
+  "totalScripts": "3490",
+  "averageExecutionTime": "99.424292337164729",
+  "averageScriptExecutionTime": "71.878707555646912"
+}, {
+  "canonicalDomain": "*.opmnstr.com",
+  "totalExecutionTime": "1063984.7489999828",
+  "totalOccurrences": "2592",
+  "totalScripts": "6263",
+  "averageExecutionTime": "410.487943287031",
+  "averageScriptExecutionTime": "127.23773736501479"
+}, {
+  "canonicalDomain": "*.signifyd.com",
+  "totalExecutionTime": "3838786.9719999856",
+  "totalOccurrences": "2567",
+  "totalScripts": "8083",
+  "averageExecutionTime": "1495.4370751850349",
+  "averageScriptExecutionTime": "484.12585491231681"
+}, {
+  "canonicalDomain": "*.cloudinary.com",
+  "totalExecutionTime": "1277041.5030000003",
+  "totalOccurrences": "2560",
+  "totalScripts": "4223",
+  "averageExecutionTime": "498.84433710937515",
+  "averageScriptExecutionTime": "263.1819368686443"
+}, {
+  "canonicalDomain": "*.seedtag.com",
+  "totalExecutionTime": "3785134.3449999946",
+  "totalOccurrences": "2514",
+  "totalScripts": "9616",
+  "averageExecutionTime": "1505.622253381063",
+  "averageScriptExecutionTime": "403.07168297337068"
+}, {
+  "canonicalDomain": "*.bstatic.com",
+  "totalExecutionTime": "1279051.3389999988",
+  "totalOccurrences": "2490",
+  "totalScripts": "5192",
+  "averageExecutionTime": "513.67523654618333",
+  "averageScriptExecutionTime": "230.61546822455634"
+}, {
+  "canonicalDomain": "*.rackcdn.com",
+  "totalExecutionTime": "2890807.4970000023",
+  "totalOccurrences": "2454",
+  "totalScripts": "7848",
+  "averageExecutionTime": "1177.9981650366749",
+  "averageScriptExecutionTime": "391.41297130874773"
+}, {
+  "canonicalDomain": "*.pixel.ad",
+  "totalExecutionTime": "182835.36700000017",
+  "totalOccurrences": "2419",
+  "totalScripts": "2693",
+  "averageExecutionTime": "75.583037205456918",
+  "averageScriptExecutionTime": "66.529163083918917"
+}, {
+  "canonicalDomain": "*.evidon.com",
+  "totalExecutionTime": "1180716.8030000008",
+  "totalOccurrences": "2382",
+  "totalScripts": "4646",
+  "averageExecutionTime": "495.68295675902618",
+  "averageScriptExecutionTime": "271.72373099636161"
+}, {
+  "canonicalDomain": "*.trackjs.com",
+  "totalExecutionTime": "1688601.9279999996",
+  "totalOccurrences": "2353",
+  "totalScripts": "2353",
+  "averageExecutionTime": "717.63787845303807",
+  "averageScriptExecutionTime": "717.63787845303807"
+}, {
+  "canonicalDomain": "*.dealer.com",
+  "totalExecutionTime": "783702.341999998",
+  "totalOccurrences": "2334",
+  "totalScripts": "2426",
+  "averageExecutionTime": "335.77649614395779",
+  "averageScriptExecutionTime": "318.68607307911941"
+}, {
+  "canonicalDomain": "*.apple.com",
+  "totalExecutionTime": "400807.64599999978",
+  "totalOccurrences": "2333",
+  "totalScripts": "3393",
+  "averageExecutionTime": "171.79924817831093",
+  "averageScriptExecutionTime": "91.058007958606751"
+}, {
+  "canonicalDomain": "*.adyen.com",
+  "totalExecutionTime": "4770436.1340000192",
+  "totalOccurrences": "2332",
+  "totalScripts": "4788",
+  "averageExecutionTime": "2045.6415668953728",
+  "averageScriptExecutionTime": "735.88444918524976"
+}, {
+  "canonicalDomain": "*.izooto.com",
+  "totalExecutionTime": "1444950.7869999981",
+  "totalOccurrences": "2302",
+  "totalScripts": "2347",
+  "averageExecutionTime": "627.69365204170265",
+  "averageScriptExecutionTime": "619.78409622067636"
+}, {
+  "canonicalDomain": "*.bownow.jp",
+  "totalExecutionTime": "1137089.8359999973",
+  "totalOccurrences": "2295",
+  "totalScripts": "4899",
+  "averageExecutionTime": "495.46398082788568",
+  "averageScriptExecutionTime": "230.7417787327519"
+}, {
+  "canonicalDomain": "*.appcues.com",
+  "totalExecutionTime": "1392157.6319999904",
+  "totalOccurrences": "2283",
+  "totalScripts": "2456",
+  "averageExecutionTime": "609.79309329828777",
+  "averageScriptExecutionTime": "573.96277387209477"
+}, {
+  "canonicalDomain": "polldaddy.com",
+  "totalExecutionTime": "288801.98999999947",
+  "totalOccurrences": "2257",
+  "totalScripts": "3207",
+  "averageExecutionTime": "127.958347363757",
+  "averageScriptExecutionTime": "89.532376908695667"
+}, {
+  "canonicalDomain": "*.secomapp.com",
+  "totalExecutionTime": "2447837.7629999858",
+  "totalOccurrences": "2228",
+  "totalScripts": "2242",
+  "averageExecutionTime": "1098.6704501795273",
+  "averageScriptExecutionTime": "1095.2649567773724"
+}, {
+  "canonicalDomain": "*.luigisbox.com",
+  "totalExecutionTime": "2690781.6150000035",
+  "totalOccurrences": "2221",
+  "totalScripts": "5377",
+  "averageExecutionTime": "1211.5180616839243",
+  "averageScriptExecutionTime": "439.48914498724304"
+}, {
+  "canonicalDomain": "*.demandbase.com",
+  "totalExecutionTime": "278833.24999999965",
+  "totalOccurrences": "2209",
+  "totalScripts": "2235",
+  "averageExecutionTime": "126.22600724309648",
+  "averageScriptExecutionTime": "124.31364825712987"
+}, {
+  "canonicalDomain": "*.owneriq.net",
+  "totalExecutionTime": "264178.37299999996",
+  "totalOccurrences": "2205",
+  "totalScripts": "2288",
+  "averageExecutionTime": "119.808785941043",
+  "averageScriptExecutionTime": "116.01957883597885"
+}, {
+  "canonicalDomain": "*.boomtrain.com",
+  "totalExecutionTime": "351388.02299999987",
+  "totalOccurrences": "2181",
+  "totalScripts": "2187",
+  "averageExecutionTime": "161.11326134800538",
+  "averageScriptExecutionTime": "160.85476715573881"
+}, {
+  "canonicalDomain": "*.revolvermaps.com",
+  "totalExecutionTime": "2137890.0110000004",
+  "totalOccurrences": "2174",
+  "totalScripts": "2685",
+  "averageExecutionTime": "983.39006945722167",
+  "averageScriptExecutionTime": "770.11951962588171"
+}, {
+  "canonicalDomain": "*.speedcurve.com",
+  "totalExecutionTime": "115143.16300000006",
+  "totalOccurrences": "2169",
+  "totalScripts": "2171",
+  "averageExecutionTime": "53.085828953434678",
+  "averageScriptExecutionTime": "53.049057630244334"
+}, {
+  "canonicalDomain": "*.ipify.org",
+  "totalExecutionTime": "284087.74199999991",
+  "totalOccurrences": "2159",
+  "totalScripts": "2162",
+  "averageExecutionTime": "131.58302084298276",
+  "averageScriptExecutionTime": "131.28614937471056"
+}, {
+  "canonicalDomain": "*.webengage.co",
+  "totalExecutionTime": "573567.51499999978",
+  "totalOccurrences": "2158",
+  "totalScripts": "3540",
+  "averageExecutionTime": "265.78661492122347",
+  "averageScriptExecutionTime": "151.55195715168372"
+}, {
+  "canonicalDomain": "*.beeketing.com",
+  "totalExecutionTime": "2159945.3529999936",
+  "totalOccurrences": "2144",
+  "totalScripts": "8614",
+  "averageExecutionTime": "1007.4371982276091",
+  "averageScriptExecutionTime": "246.77138388414997"
+}, {
+  "canonicalDomain": "*.adocean.pl",
+  "totalExecutionTime": "1307446.2659999977",
+  "totalOccurrences": "2137",
+  "totalScripts": "3690",
+  "averageExecutionTime": "611.8138820776785",
+  "averageScriptExecutionTime": "305.97724212625553"
+}, {
+  "canonicalDomain": "*.raygun.io",
+  "totalExecutionTime": "192877.24999999971",
+  "totalOccurrences": "2128",
+  "totalScripts": "2130",
+  "averageExecutionTime": "90.637805451127733",
+  "averageScriptExecutionTime": "90.523186560150378"
+}, {
+  "canonicalDomain": "*.iesnare.com",
+  "totalExecutionTime": "226800.78299999994",
+  "totalOccurrences": "2098",
+  "totalScripts": "2103",
+  "averageExecutionTime": "108.10332840800763",
+  "averageScriptExecutionTime": "107.76723117254525"
+}, {
+  "canonicalDomain": "*.authorize.net",
+  "totalExecutionTime": "270585.817",
+  "totalOccurrences": "2065",
+  "totalScripts": "2406",
+  "averageExecutionTime": "131.03429394673131",
+  "averageScriptExecutionTime": "79.886759752584723"
+}, {
+  "canonicalDomain": "*.refersion.com",
+  "totalExecutionTime": "503218.74400000012",
+  "totalOccurrences": "2056",
+  "totalScripts": "2460",
+  "averageExecutionTime": "244.75619844357982",
+  "averageScriptExecutionTime": "207.65629357976633"
+}, {
+  "canonicalDomain": "*.videoplayerhub.com",
+  "totalExecutionTime": "133757.67699999991",
+  "totalOccurrences": "2053",
+  "totalScripts": "2053",
+  "averageExecutionTime": "65.1523024841695",
+  "averageScriptExecutionTime": "65.1523024841695"
+}, {
+  "canonicalDomain": "*.wisepops.com",
+  "totalExecutionTime": "2535909.7750000185",
+  "totalOccurrences": "2044",
+  "totalScripts": "3559",
+  "averageExecutionTime": "1240.6603595890494",
+  "averageScriptExecutionTime": "750.78008253075609"
+}, {
+  "canonicalDomain": "*.gigya.com",
+  "totalExecutionTime": "2537293.2329999991",
+  "totalOccurrences": "2041",
+  "totalScripts": "7779",
+  "averageExecutionTime": "1243.1617996080363",
+  "averageScriptExecutionTime": "462.55802305193"
+}, {
+  "canonicalDomain": "*.feefo.com",
+  "totalExecutionTime": "1260270.0719999985",
+  "totalOccurrences": "2034",
+  "totalScripts": "6615",
+  "averageExecutionTime": "619.60180530973355",
+  "averageScriptExecutionTime": "193.8011385646391"
+}, {
+  "canonicalDomain": "*.bkrtx.com",
+  "totalExecutionTime": "243440.087",
+  "totalOccurrences": "2034",
+  "totalScripts": "2091",
+  "averageExecutionTime": "119.68539183874131",
+  "averageScriptExecutionTime": "118.51026106194698"
+}, {
+  "canonicalDomain": "*.jscache.com",
+  "totalExecutionTime": "264800.55099999951",
+  "totalOccurrences": "2021",
+  "totalScripts": "2610",
+  "averageExecutionTime": "131.02451806036586",
+  "averageScriptExecutionTime": "87.505492392968961"
+}, {
+  "canonicalDomain": "*.adnami.io",
+  "totalExecutionTime": "328829.87599999987",
+  "totalOccurrences": "2010",
+  "totalScripts": "3079",
+  "averageExecutionTime": "163.59695323383062",
+  "averageScriptExecutionTime": "103.13489957237628"
+}, {
+  "canonicalDomain": "*.upsellit.com",
+  "totalExecutionTime": "495980.02900000004",
+  "totalOccurrences": "1994",
+  "totalScripts": "2108",
+  "averageExecutionTime": "248.73622316950841",
+  "averageScriptExecutionTime": "236.7923491307256"
+}, {
+  "canonicalDomain": "*.juicyads.com",
+  "totalExecutionTime": "432570.53700000024",
+  "totalOccurrences": "1993",
+  "totalScripts": "2368",
+  "averageExecutionTime": "217.04492574009015",
+  "averageScriptExecutionTime": "195.24888083709661"
+}, {
+  "canonicalDomain": "*.clerk.io",
+  "totalExecutionTime": "1511233.5480000009",
+  "totalOccurrences": "1945",
+  "totalScripts": "5384",
+  "averageExecutionTime": "776.9838293059114",
+  "averageScriptExecutionTime": "247.4184966223936"
+}, {
+  "canonicalDomain": "*.foxentry.cz",
+  "totalExecutionTime": "521125.65400001494",
+  "totalOccurrences": "1927",
+  "totalScripts": "2952",
+  "averageExecutionTime": "270.43365542294509",
+  "averageScriptExecutionTime": "161.2126859539911"
+}, {
+  "canonicalDomain": "*.addshoppers.com",
+  "totalExecutionTime": "650271.75799999933",
+  "totalOccurrences": "1915",
+  "totalScripts": "2800",
+  "averageExecutionTime": "339.56749765013046",
+  "averageScriptExecutionTime": "219.35181875543921"
+}, {
+  "canonicalDomain": "*.reviews.co.uk",
+  "totalExecutionTime": "320076.49200000049",
+  "totalOccurrences": "1897",
+  "totalScripts": "2716",
+  "averageExecutionTime": "168.72772377438051",
+  "averageScriptExecutionTime": "129.91623321535249"
+}, {
+  "canonicalDomain": "*.circulate.com",
+  "totalExecutionTime": "164659.74399999989",
+  "totalOccurrences": "1878",
+  "totalScripts": "1878",
+  "averageExecutionTime": "87.678244941427138",
+  "averageScriptExecutionTime": "87.678244941427138"
+}, {
+  "canonicalDomain": "*.browsealoud.com",
+  "totalExecutionTime": "569926.906999998",
+  "totalOccurrences": "1874",
+  "totalScripts": "7078",
+  "averageExecutionTime": "304.12321611526107",
+  "averageScriptExecutionTime": "75.998190745964"
+}, {
+  "canonicalDomain": "*.dynamicyield.com",
+  "totalExecutionTime": "3613991.1140007568",
+  "totalOccurrences": "1860",
+  "totalScripts": "5211",
+  "averageExecutionTime": "1943.0059752692216",
+  "averageScriptExecutionTime": "646.01792014349553"
+}, {
+  "canonicalDomain": "*.adswizz.com",
+  "totalExecutionTime": "529815.52699999989",
+  "totalOccurrences": "1857",
+  "totalScripts": "2329",
+  "averageExecutionTime": "285.30723047926688",
+  "averageScriptExecutionTime": "249.52723635792458"
+}, {
+  "canonicalDomain": "*.marketo.com",
+  "totalExecutionTime": "725619.98699999833",
+  "totalOccurrences": "1850",
+  "totalScripts": "3238",
+  "averageExecutionTime": "392.22702000000004",
+  "averageScriptExecutionTime": "260.41639094851934"
+}, {
+  "canonicalDomain": "*.ladsp.com",
+  "totalExecutionTime": "266982.78200000018",
+  "totalOccurrences": "1850",
+  "totalScripts": "4269",
+  "averageExecutionTime": "144.31501729729709",
+  "averageScriptExecutionTime": "61.513826323577874"
+}, {
+  "canonicalDomain": "*.riskified.com",
+  "totalExecutionTime": "403594.49499999953",
+  "totalOccurrences": "1848",
+  "totalScripts": "1865",
+  "averageExecutionTime": "218.39528950216459",
+  "averageScriptExecutionTime": "217.17477586580074"
+}, {
+  "canonicalDomain": "*.livetex.ru",
+  "totalExecutionTime": "405258.85400000022",
+  "totalOccurrences": "1838",
+  "totalScripts": "3507",
+  "averageExecutionTime": "220.48903917301411",
+  "averageScriptExecutionTime": "105.76062290403658"
+}, {
+  "canonicalDomain": "*.purecars.com",
+  "totalExecutionTime": "1332743.7689999915",
+  "totalOccurrences": "1814",
+  "totalScripts": "3069",
+  "averageExecutionTime": "734.69888037485691",
+  "averageScriptExecutionTime": "463.06303606210605"
+}, {
+  "canonicalDomain": "*.hybrid.ai",
+  "totalExecutionTime": "153270.57300000015",
+  "totalOccurrences": "1807",
+  "totalScripts": "2628",
+  "averageExecutionTime": "84.820460985058176",
+  "averageScriptExecutionTime": "56.760993359158874"
+}, {
+  "canonicalDomain": "*.appboycdn.com",
+  "totalExecutionTime": "289994.13300000038",
+  "totalOccurrences": "1801",
+  "totalScripts": "1857",
+  "averageExecutionTime": "161.01839700166576",
+  "averageScriptExecutionTime": "156.57435637608748"
+}, {
+  "canonicalDomain": "*.karte.io",
+  "totalExecutionTime": "1581239.461000002",
+  "totalOccurrences": "1755",
+  "totalScripts": "4081",
+  "averageExecutionTime": "900.99114586894632",
+  "averageScriptExecutionTime": "319.53231298570546"
+}, {
+  "canonicalDomain": "*.4dex.io",
+  "totalExecutionTime": "8111.812999999991",
+  "totalOccurrences": "1746",
+  "totalScripts": "1759",
+  "averageExecutionTime": "4.6459410080183341",
+  "averageScriptExecutionTime": "4.455699599083621"
+}, {
+  "canonicalDomain": "*.scarabresearch.com",
+  "totalExecutionTime": "333492.05699999991",
+  "totalOccurrences": "1731",
+  "totalScripts": "3352",
+  "averageExecutionTime": "192.658611785095",
+  "averageScriptExecutionTime": "96.483323416137111"
+}, {
+  "canonicalDomain": "*.trustcommander.net",
+  "totalExecutionTime": "299087.14699999971",
+  "totalOccurrences": "1701",
+  "totalScripts": "2035",
+  "averageExecutionTime": "175.83018636096403",
+  "averageScriptExecutionTime": "130.08454076033698"
+}, {
+  "canonicalDomain": "*.wishpond.com",
+  "totalExecutionTime": "875785.95099999628",
+  "totalOccurrences": "1698",
+  "totalScripts": "2241",
+  "averageExecutionTime": "515.77500058892565",
+  "averageScriptExecutionTime": "395.6077112387099"
+}, {
+  "canonicalDomain": "*.ml314.com",
+  "totalExecutionTime": "123213.65099999998",
+  "totalOccurrences": "1672",
+  "totalScripts": "1703",
+  "averageExecutionTime": "73.692375000000027",
+  "averageScriptExecutionTime": "72.293284688995243"
+}, {
+  "canonicalDomain": "*.fastly-insights.com",
+  "totalExecutionTime": "176626.86800000007",
+  "totalOccurrences": "1631",
+  "totalScripts": "1631",
+  "averageExecutionTime": "108.29360392397305",
+  "averageScriptExecutionTime": "108.29360392397305"
+}, {
+  "canonicalDomain": "*.kargo.com",
+  "totalExecutionTime": "1076647.8270000019",
+  "totalOccurrences": "1602",
+  "totalScripts": "2139",
+  "averageExecutionTime": "672.064810861424",
+  "averageScriptExecutionTime": "328.05235769722424"
+}, {
+  "canonicalDomain": "*.basis.net",
+  "totalExecutionTime": "129160.832",
+  "totalOccurrences": "1593",
+  "totalScripts": "1593",
+  "averageExecutionTime": "81.080246076585155",
+  "averageScriptExecutionTime": "81.080246076585155"
+}, {
+  "canonicalDomain": "*.geoedge.com",
+  "totalExecutionTime": "1326738.5719999967",
+  "totalOccurrences": "1592",
+  "totalScripts": "2641",
+  "averageExecutionTime": "833.37849999999855",
+  "averageScriptExecutionTime": "446.37502313651424"
+}, {
+  "canonicalDomain": "*.accuweather.com",
+  "totalExecutionTime": "268890.74699999974",
+  "totalOccurrences": "1579",
+  "totalScripts": "1599",
+  "averageExecutionTime": "170.2917967067763",
+  "averageScriptExecutionTime": "166.84620477095203"
+}, {
+  "canonicalDomain": "*.wufoo.com",
+  "totalExecutionTime": "294276.72400000034",
+  "totalOccurrences": "1565",
+  "totalScripts": "2508",
+  "averageExecutionTime": "188.03624536741211",
+  "averageScriptExecutionTime": "117.03334805111812"
+}, {
+  "canonicalDomain": "*.convertful.com",
+  "totalExecutionTime": "246959.61399999991",
+  "totalOccurrences": "1556",
+  "totalScripts": "1558",
+  "averageExecutionTime": "158.71440488431844",
+  "averageScriptExecutionTime": "158.59187789203065"
+}, {
+  "canonicalDomain": "*.powerreviews.com",
+  "totalExecutionTime": "1225615.4699999955",
+  "totalOccurrences": "1524",
+  "totalScripts": "4686",
+  "averageExecutionTime": "804.20962598424956",
+  "averageScriptExecutionTime": "262.74418490813559"
+}, {
+  "canonicalDomain": "*.marker.io",
+  "totalExecutionTime": "1866770.2969999996",
+  "totalOccurrences": "1508",
+  "totalScripts": "2662",
+  "averageExecutionTime": "1237.911337533154",
+  "averageScriptExecutionTime": "639.3143123894763"
+}, {
+  "canonicalDomain": "*.justuno.com",
+  "totalExecutionTime": "711028.83500000031",
+  "totalOccurrences": "1474",
+  "totalScripts": "3609",
+  "averageExecutionTime": "482.38048507462639",
+  "averageScriptExecutionTime": "171.79112138495816"
+}, {
+  "canonicalDomain": "*.twitch.tv",
+  "totalExecutionTime": "21154526.635000587",
+  "totalOccurrences": "1474",
+  "totalScripts": "15831",
+  "averageExecutionTime": "14351.78197761232",
+  "averageScriptExecutionTime": "1220.9918477740011"
+}, {
+  "canonicalDomain": "*.pusher.com",
+  "totalExecutionTime": "136812.93299999996",
+  "totalOccurrences": "1456",
+  "totalScripts": "1459",
+  "averageExecutionTime": "93.96492651098896",
+  "averageScriptExecutionTime": "93.819447802197715"
+}, {
+  "canonicalDomain": "*.commander1.com",
+  "totalExecutionTime": "415877.74999999942",
+  "totalOccurrences": "1455",
+  "totalScripts": "2447",
+  "averageExecutionTime": "285.82663230240553",
+  "averageScriptExecutionTime": "169.63650553264594"
+}, {
+  "canonicalDomain": "*.rollbar.com",
+  "totalExecutionTime": "134051.42099999977",
+  "totalOccurrences": "1442",
+  "totalScripts": "1446",
+  "averageExecutionTime": "92.962150485436823",
+  "averageScriptExecutionTime": "91.940928848821045"
+}, {
+  "canonicalDomain": "*.kameleoon.com",
+  "totalExecutionTime": "862257.12799999933",
+  "totalOccurrences": "1438",
+  "totalScripts": "1456",
+  "averageExecutionTime": "599.62248122392054",
+  "averageScriptExecutionTime": "599.17806571627261"
+}, {
+  "canonicalDomain": "*.ulogin.ru",
+  "totalExecutionTime": "4171421.16500001",
+  "totalOccurrences": "1427",
+  "totalScripts": "1712",
+  "averageExecutionTime": "2923.21034688157",
+  "averageScriptExecutionTime": "2677.7134011312478"
+}, {
+  "canonicalDomain": "*.klevu.com",
+  "totalExecutionTime": "617962.1049999973",
+  "totalOccurrences": "1415",
+  "totalScripts": "2582",
+  "averageExecutionTime": "436.72233568904437",
+  "averageScriptExecutionTime": "211.95100138986979"
+}, {
+  "canonicalDomain": "*.exponea.com",
+  "totalExecutionTime": "155901.24399999995",
+  "totalOccurrences": "1398",
+  "totalScripts": "1464",
+  "averageExecutionTime": "111.51734191702445",
+  "averageScriptExecutionTime": "104.05526716738188"
+}, {
+  "canonicalDomain": "*.rewardstyle.com",
+  "totalExecutionTime": "209550.61299999966",
+  "totalOccurrences": "1397",
+  "totalScripts": "1612",
+  "averageExecutionTime": "150.00043879742304",
+  "averageScriptExecutionTime": "129.21980386542583"
+}, {
+  "canonicalDomain": "*.sail-horizon.com",
+  "totalExecutionTime": "117540.63199999997",
+  "totalOccurrences": "1394",
+  "totalScripts": "1407",
+  "averageExecutionTime": "84.318961262553785",
+  "averageScriptExecutionTime": "83.7793888091823"
+}, {
+  "canonicalDomain": "*.fout.jp",
+  "totalExecutionTime": "81769.608999999968",
+  "totalOccurrences": "1381",
+  "totalScripts": "1535",
+  "averageExecutionTime": "59.210433743664062",
+  "averageScriptExecutionTime": "52.605367849384457"
+}, {
+  "canonicalDomain": "*.albacross.com",
+  "totalExecutionTime": "87542.316",
+  "totalOccurrences": "1344",
+  "totalScripts": "1344",
+  "averageExecutionTime": "65.135651785714288",
+  "averageScriptExecutionTime": "65.135651785714288"
+}, {
+  "canonicalDomain": "uniconsent.mgr.consensu.org",
+  "totalExecutionTime": "440260.57199999905",
+  "totalOccurrences": "1334",
+  "totalScripts": "2059",
+  "averageExecutionTime": "330.03041379310309",
+  "averageScriptExecutionTime": "210.69064180409774"
+}, {
+  "canonicalDomain": "*.foursixty.com",
+  "totalExecutionTime": "267395.62499999994",
+  "totalOccurrences": "1325",
+  "totalScripts": "1365",
+  "averageExecutionTime": "201.80801886792466",
+  "averageScriptExecutionTime": "196.676323018868"
+}, {
+  "canonicalDomain": "*.netlify.com",
+  "totalExecutionTime": "257028.69400000005",
+  "totalOccurrences": "1323",
+  "totalScripts": "1324",
+  "averageExecutionTime": "194.27716855631141",
+  "averageScriptExecutionTime": "194.18300907029467"
+}, {
+  "canonicalDomain": "*.bizible.com",
+  "totalExecutionTime": "464930.53299999877",
+  "totalOccurrences": "1316",
+  "totalScripts": "1317",
+  "averageExecutionTime": "353.29067857142741",
+  "averageScriptExecutionTime": "352.99765881458808"
+}, {
+  "canonicalDomain": "*.shareaholic.com",
+  "totalExecutionTime": "123122.174",
+  "totalOccurrences": "1297",
+  "totalScripts": "1382",
+  "averageExecutionTime": "94.928430223592869",
+  "averageScriptExecutionTime": "85.443650295553809"
+}, {
+  "canonicalDomain": "*.polyfill.io",
+  "totalExecutionTime": "269659.35599999991",
+  "totalOccurrences": "1293",
+  "totalScripts": "1293",
+  "averageExecutionTime": "208.55325290023163",
+  "averageScriptExecutionTime": "208.55325290023163"
+}, {
+  "canonicalDomain": "*.woopra.com",
+  "totalExecutionTime": "113294.89100000044",
+  "totalOccurrences": "1274",
+  "totalScripts": "1287",
+  "averageExecutionTime": "88.9284858712719",
+  "averageScriptExecutionTime": "77.676498560962955"
+}, {
+  "canonicalDomain": "*.usabilla.com",
+  "totalExecutionTime": "204390.80500000017",
+  "totalOccurrences": "1272",
+  "totalScripts": "1320",
+  "averageExecutionTime": "160.68459512578613",
+  "averageScriptExecutionTime": "150.60841264413008"
+}, {
+  "canonicalDomain": "*.bounceexchange.com",
+  "totalExecutionTime": "1669223.7830000005",
+  "totalOccurrences": "1249",
+  "totalScripts": "5489",
+  "averageExecutionTime": "1336.4481849479575",
+  "averageScriptExecutionTime": "293.32517937778829"
+}, {
+  "canonicalDomain": "*.customer.io",
+  "totalExecutionTime": "216099.60299999948",
+  "totalOccurrences": "1247",
+  "totalScripts": "1530",
+  "averageExecutionTime": "173.29559182036877",
+  "averageScriptExecutionTime": "129.30231180356643"
+}, {
+  "canonicalDomain": "*.innovid.com",
+  "totalExecutionTime": "165864.80299999993",
+  "totalOccurrences": "1228",
+  "totalScripts": "1343",
+  "averageExecutionTime": "135.06905781758931",
+  "averageScriptExecutionTime": "110.71837719417299"
+}, {
+  "canonicalDomain": "*.revcontent.com",
+  "totalExecutionTime": "1060081.9949999994",
+  "totalOccurrences": "1225",
+  "totalScripts": "2788",
+  "averageExecutionTime": "865.373057142856",
+  "averageScriptExecutionTime": "373.46721820408106"
+}, {
+  "canonicalDomain": "*.getdrip.com",
+  "totalExecutionTime": "110117.31900000003",
+  "totalOccurrences": "1216",
+  "totalScripts": "1886",
+  "averageExecutionTime": "90.557005756578974",
+  "averageScriptExecutionTime": "57.55118405441192"
+}, {
+  "canonicalDomain": "*.disqus.com",
+  "totalExecutionTime": "3132408.5939999875",
+  "totalOccurrences": "1212",
+  "totalScripts": "6129",
+  "averageExecutionTime": "2584.4955396039554",
+  "averageScriptExecutionTime": "464.48232191722013"
+}, {
+  "canonicalDomain": "d2r1yp2w7bby2u.cloudfront.net",
+  "totalExecutionTime": "153534.01699999996",
+  "totalOccurrences": "1211",
+  "totalScripts": "1224",
+  "averageExecutionTime": "126.78283815028892",
+  "averageScriptExecutionTime": "125.21034227910805"
+}, {
+  "canonicalDomain": "*.global-e.com",
+  "totalExecutionTime": "944504.10099999746",
+  "totalOccurrences": "1209",
+  "totalScripts": "2925",
+  "averageExecutionTime": "781.227544251445",
+  "averageScriptExecutionTime": "357.79796159927162"
+}, {
+  "canonicalDomain": "*.listrak.com",
+  "totalExecutionTime": "458169.52899999887",
+  "totalOccurrences": "1204",
+  "totalScripts": "1684",
+  "averageExecutionTime": "380.53947591362095",
+  "averageScriptExecutionTime": "265.3084993632333"
+}, {
+  "canonicalDomain": "*.nosto.com",
+  "totalExecutionTime": "713149.12999999942",
+  "totalOccurrences": "1174",
+  "totalScripts": "1317",
+  "averageExecutionTime": "607.45241056218015",
+  "averageScriptExecutionTime": "560.8446680863143"
+}, {
+  "canonicalDomain": "*.quantummetric.com",
+  "totalExecutionTime": "1480916.4360000009",
+  "totalOccurrences": "1170",
+  "totalScripts": "1179",
+  "averageExecutionTime": "1265.7405435897451",
+  "averageScriptExecutionTime": "1252.368419658121"
+}, {
+  "canonicalDomain": "*.stickyadstv.com",
+  "totalExecutionTime": "2124078.8589999988",
+  "totalOccurrences": "1161",
+  "totalScripts": "1164",
+  "averageExecutionTime": "1829.5252876830289",
+  "averageScriptExecutionTime": "1829.4406356589138"
+}, {
+  "canonicalDomain": "*.flockler.com",
+  "totalExecutionTime": "433842.99899999984",
+  "totalOccurrences": "1154",
+  "totalScripts": "1391",
+  "averageExecutionTime": "375.94713951473028",
+  "averageScriptExecutionTime": "300.74792398902332"
+}, {
+  "canonicalDomain": "*.yieldmo.com",
+  "totalExecutionTime": "150586.61800000022",
+  "totalOccurrences": "1154",
+  "totalScripts": "1239",
+  "averageExecutionTime": "130.49100346620443",
+  "averageScriptExecutionTime": "84.035388431542472"
+}, {
+  "canonicalDomain": "*.eyeota.net",
+  "totalExecutionTime": "98322.388",
+  "totalOccurrences": "1139",
+  "totalScripts": "1307",
+  "averageExecutionTime": "86.323431079894661",
+  "averageScriptExecutionTime": "75.648420398010018"
+}, {
+  "canonicalDomain": "*.cpex.cz",
+  "totalExecutionTime": "573126.63799999782",
+  "totalOccurrences": "1137",
+  "totalScripts": "1963",
+  "averageExecutionTime": "504.0691627088803",
+  "averageScriptExecutionTime": "309.10215721195914"
+}, {
+  "canonicalDomain": "*.checkout.com",
+  "totalExecutionTime": "114304.16300000012",
+  "totalOccurrences": "1133",
+  "totalScripts": "1178",
+  "averageExecutionTime": "100.88628684907327",
+  "averageScriptExecutionTime": "82.239051715140363"
+}, {
+  "canonicalDomain": "*.npttech.com",
+  "totalExecutionTime": "1035409.2479999989",
+  "totalOccurrences": "1131",
+  "totalScripts": "2050",
+  "averageExecutionTime": "915.48120954906926",
+  "averageScriptExecutionTime": "558.12301409958036"
+}, {
+  "canonicalDomain": "*.getresponse.com",
+  "totalExecutionTime": "197783.16500000033",
+  "totalOccurrences": "1111",
+  "totalScripts": "2392",
+  "averageExecutionTime": "178.02265076507666",
+  "averageScriptExecutionTime": "85.553991928657268"
+}, {
+  "canonicalDomain": "*.typepad.com",
+  "totalExecutionTime": "456255.74499999679",
+  "totalOccurrences": "1101",
+  "totalScripts": "1689",
+  "averageExecutionTime": "414.4012216167099",
+  "averageScriptExecutionTime": "260.29982950131762"
+}, {
+  "canonicalDomain": "*.swiftype.com",
+  "totalExecutionTime": "383778.1379999991",
+  "totalOccurrences": "1096",
+  "totalScripts": "1103",
+  "averageExecutionTime": "350.16253467153234",
+  "averageScriptExecutionTime": "347.95412180656848"
+}, {
+  "canonicalDomain": "*.o2.pl",
+  "totalExecutionTime": "701278.07400000282",
+  "totalOccurrences": "1094",
+  "totalScripts": "1371",
+  "averageExecutionTime": "641.022005484463",
+  "averageScriptExecutionTime": "334.27450738878809"
+}, {
+  "canonicalDomain": "*.lytics.io",
+  "totalExecutionTime": "315574.76599999861",
+  "totalOccurrences": "1072",
+  "totalScripts": "2366",
+  "averageExecutionTime": "294.37944589552109",
+  "averageScriptExecutionTime": "136.7914911069642"
+}, {
+  "canonicalDomain": "*.clickguardian.app",
+  "totalExecutionTime": "189936.17300000016",
+  "totalOccurrences": "1062",
+  "totalScripts": "1086",
+  "averageExecutionTime": "178.84762052730684",
+  "averageScriptExecutionTime": "170.78277401129947"
+}, {
+  "canonicalDomain": "*.vidyard.com",
+  "totalExecutionTime": "1038055.2989999995",
+  "totalOccurrences": "1061",
+  "totalScripts": "3535",
+  "averageExecutionTime": "978.3744571159275",
+  "averageScriptExecutionTime": "204.93132182254567"
+}, {
+  "canonicalDomain": "*.contextweb.com",
+  "totalExecutionTime": "24147.259999999977",
+  "totalOccurrences": "1057",
+  "totalScripts": "1104",
+  "averageExecutionTime": "22.845089877010388",
+  "averageScriptExecutionTime": "20.858903532008796"
+}, {
+  "canonicalDomain": "*.comm100.com",
+  "totalExecutionTime": "465135.33499999967",
+  "totalOccurrences": "1038",
+  "totalScripts": "2230",
+  "averageExecutionTime": "448.10725915221576",
+  "averageScriptExecutionTime": "212.78403553307635"
+}, {
+  "canonicalDomain": "*.ib-ibi.com",
+  "totalExecutionTime": "32.214000000000027",
+  "totalOccurrences": "1018",
+  "totalScripts": "1022",
+  "averageExecutionTime": "0.031644400785854628",
+  "averageScriptExecutionTime": "0.031623772102161093"
+}, {
+  "canonicalDomain": "*.tvsquared.com",
+  "totalExecutionTime": "166582.44599999892",
+  "totalOccurrences": "1014",
+  "totalScripts": "1014",
+  "averageExecutionTime": "164.28249112425945",
+  "averageScriptExecutionTime": "164.28249112425945"
+}, {
+  "canonicalDomain": "*.braintreegateway.com",
+  "totalExecutionTime": "137544.29499999993",
+  "totalOccurrences": "1010",
+  "totalScripts": "1385",
+  "averageExecutionTime": "136.18247029702962",
+  "averageScriptExecutionTime": "96.536712287443"
+}, {
+  "canonicalDomain": "*.pingdom.net",
+  "totalExecutionTime": "65068.766000000076",
+  "totalOccurrences": "1008",
+  "totalScripts": "1010",
+  "averageExecutionTime": "64.5523472222222",
+  "averageScriptExecutionTime": "64.450818452381014"
+}, {
+  "canonicalDomain": "*.snapengage.com",
+  "totalExecutionTime": "110735.74499999998",
+  "totalOccurrences": "1000",
+  "totalScripts": "1072",
+  "averageExecutionTime": "110.73574499999998",
+  "averageScriptExecutionTime": "103.43983599999996"
+}, {
+  "canonicalDomain": "*.addthis.com",
+  "totalExecutionTime": "237173.28299999988",
+  "totalOccurrences": "997",
+  "totalScripts": "1676",
+  "averageExecutionTime": "237.88694383149411",
+  "averageScriptExecutionTime": "132.53156464089224"
+}, {
+  "canonicalDomain": "*.sirv.com",
+  "totalExecutionTime": "536785.09599999909",
+  "totalOccurrences": "992",
+  "totalScripts": "1047",
+  "averageExecutionTime": "541.11400806451559",
+  "averageScriptExecutionTime": "491.27831334005322"
+}, {
+  "canonicalDomain": "*.mparticle.com",
+  "totalExecutionTime": "358705.61999999959",
+  "totalOccurrences": "991",
+  "totalScripts": "1092",
+  "averageExecutionTime": "361.96328960645792",
+  "averageScriptExecutionTime": "343.85269172552961"
+}, {
+  "canonicalDomain": "*.cdn77.org",
+  "totalExecutionTime": "2579102.3349999953",
+  "totalOccurrences": "968",
+  "totalScripts": "3528",
+  "averageExecutionTime": "2664.3619163223125",
+  "averageScriptExecutionTime": "624.579275134461"
+}, {
+  "canonicalDomain": "*.truste.com",
+  "totalExecutionTime": "152388.09500000026",
+  "totalOccurrences": "964",
+  "totalScripts": "1005",
+  "averageExecutionTime": "158.07893672199188",
+  "averageScriptExecutionTime": "134.74419026625142"
+}, {
+  "canonicalDomain": "*.ada.support",
+  "totalExecutionTime": "605646.01300000178",
+  "totalOccurrences": "961",
+  "totalScripts": "2070",
+  "averageExecutionTime": "630.2247793964633",
+  "averageScriptExecutionTime": "280.4727870571333"
+}, {
+  "canonicalDomain": "*.kaltura.com",
+  "totalExecutionTime": "1827545.6530000025",
+  "totalOccurrences": "955",
+  "totalScripts": "1799",
+  "averageExecutionTime": "1913.6603696335073",
+  "averageScriptExecutionTime": "1047.7287973723826"
+}, {
+  "canonicalDomain": "*.usefathom.com",
+  "totalExecutionTime": "126594.32200000009",
+  "totalOccurrences": "947",
+  "totalScripts": "947",
+  "averageExecutionTime": "133.6793262935588",
+  "averageScriptExecutionTime": "133.6793262935588"
+}, {
+  "canonicalDomain": "*.clickagy.com",
+  "totalExecutionTime": "162492.89599999867",
+  "totalOccurrences": "938",
+  "totalScripts": "942",
+  "averageExecutionTime": "173.23336460554231",
+  "averageScriptExecutionTime": "171.325847014924"
+}, {
+  "canonicalDomain": "*.pushcrew.com",
+  "totalExecutionTime": "159795.3329999999",
+  "totalOccurrences": "935",
+  "totalScripts": "936",
+  "averageExecutionTime": "170.90409946524062",
+  "averageScriptExecutionTime": "170.83879839572168"
+}, {
+  "canonicalDomain": "*.permutive.com",
+  "totalExecutionTime": "1156393.4869999953",
+  "totalOccurrences": "932",
+  "totalScripts": "932",
+  "averageExecutionTime": "1240.7655439914124",
+  "averageScriptExecutionTime": "1240.7655439914124"
+}, {
+  "canonicalDomain": "*.cedexis-test.com",
+  "totalExecutionTime": "175133.17299999989",
+  "totalOccurrences": "912",
+  "totalScripts": "1052",
+  "averageExecutionTime": "192.03198793859644",
+  "averageScriptExecutionTime": "161.17798996710516"
+}, {
+  "canonicalDomain": "*.providesupport.com",
+  "totalExecutionTime": "70635.684999999983",
+  "totalOccurrences": "909",
+  "totalScripts": "917",
+  "averageExecutionTime": "77.707024202420314",
+  "averageScriptExecutionTime": "75.857873854052087"
+}, {
+  "canonicalDomain": "*.medtargetsystem.com",
+  "totalExecutionTime": "283333.413",
+  "totalOccurrences": "893",
+  "totalScripts": "2168",
+  "averageExecutionTime": "317.28265733482687",
+  "averageScriptExecutionTime": "126.53152196715192"
+}, {
+  "canonicalDomain": "*.ebay.com",
+  "totalExecutionTime": "475106.907999999",
+  "totalOccurrences": "892",
+  "totalScripts": "1296",
+  "averageExecutionTime": "532.63106278026794",
+  "averageScriptExecutionTime": "434.25341167075879"
+}, {
+  "canonicalDomain": "*.springserve.com",
+  "totalExecutionTime": "1044527.7709999983",
+  "totalOccurrences": "881",
+  "totalScripts": "1503",
+  "averageExecutionTime": "1185.616085130531",
+  "averageScriptExecutionTime": "664.94433066590864"
+}, {
+  "canonicalDomain": "*.truconversion.com",
+  "totalExecutionTime": "363490.00199999951",
+  "totalOccurrences": "879",
+  "totalScripts": "1006",
+  "averageExecutionTime": "413.52673720136482",
+  "averageScriptExecutionTime": "382.69056901782318"
+}, {
+  "canonicalDomain": "*.iadvize.com",
+  "totalExecutionTime": "264296.83100000024",
+  "totalOccurrences": "873",
+  "totalScripts": "2728",
+  "averageExecutionTime": "302.74551088201582",
+  "averageScriptExecutionTime": "95.389289394063354"
+}, {
+  "canonicalDomain": "*.flowplayer.org",
+  "totalExecutionTime": "221882.59899999923",
+  "totalOccurrences": "872",
+  "totalScripts": "982",
+  "averageExecutionTime": "254.45252178898954",
+  "averageScriptExecutionTime": "215.31908151758333"
+}, {
+  "canonicalDomain": "*.bootcss.com",
+  "totalExecutionTime": "402145.82399999938",
+  "totalOccurrences": "871",
+  "totalScripts": "1046",
+  "averageExecutionTime": "461.70588289322626",
+  "averageScriptExecutionTime": "389.18896582472331"
+}, {
+  "canonicalDomain": "*.lightboxcdn.com",
+  "totalExecutionTime": "742368.69699999783",
+  "totalOccurrences": "867",
+  "totalScripts": "1696",
+  "averageExecutionTime": "856.24993886966388",
+  "averageScriptExecutionTime": "448.51848244905716"
+}, {
+  "canonicalDomain": "*.appier.net",
+  "totalExecutionTime": "137925.85700000005",
+  "totalOccurrences": "865",
+  "totalScripts": "877",
+  "averageExecutionTime": "159.45185780346796",
+  "averageScriptExecutionTime": "158.5463657032754"
+}, {
+  "canonicalDomain": "*.tailtarget.com",
+  "totalExecutionTime": "155227.53900000008",
+  "totalOccurrences": "860",
+  "totalScripts": "1395",
+  "averageExecutionTime": "180.49713837209265",
+  "averageScriptExecutionTime": "91.774639844961214"
+}, {
+  "canonicalDomain": "*.dotmetrics.net",
+  "totalExecutionTime": "187583.29099999915",
+  "totalOccurrences": "855",
+  "totalScripts": "968",
+  "averageExecutionTime": "219.39566198830349",
+  "averageScriptExecutionTime": "208.19207680311845"
+}, {
+  "canonicalDomain": "*.the-ozone-project.com",
+  "totalExecutionTime": "138574.8909999998",
+  "totalOccurrences": "850",
+  "totalScripts": "918",
+  "averageExecutionTime": "163.0292835294118",
+  "averageScriptExecutionTime": "146.5635644117647"
+}, {
+  "canonicalDomain": "*.leadmanagerfx.com",
+  "totalExecutionTime": "211202.47599999729",
+  "totalOccurrences": "828",
+  "totalScripts": "895",
+  "averageExecutionTime": "255.07545410627714",
+  "averageScriptExecutionTime": "202.93528200482766"
+}, {
+  "canonicalDomain": "*.betweendigital.com",
+  "totalExecutionTime": "129358.94000000067",
+  "totalOccurrences": "827",
+  "totalScripts": "1011",
+  "averageExecutionTime": "156.41951632406372",
+  "averageScriptExecutionTime": "77.648614319303249"
+}, {
+  "canonicalDomain": "*.noibu.com",
+  "totalExecutionTime": "1478239.440000006",
+  "totalOccurrences": "821",
+  "totalScripts": "828",
+  "averageExecutionTime": "1800.5352496954995",
+  "averageScriptExecutionTime": "1789.5776319529086"
+}, {
+  "canonicalDomain": "*.maxmind.com",
+  "totalExecutionTime": "852172.44799999811",
+  "totalOccurrences": "819",
+  "totalScripts": "820",
+  "averageExecutionTime": "1040.5035995115991",
+  "averageScriptExecutionTime": "1039.7375592185604"
+}, {
+  "canonicalDomain": "*.kampyle.com",
+  "totalExecutionTime": "617984.42799999786",
+  "totalOccurrences": "811",
+  "totalScripts": "1900",
+  "averageExecutionTime": "762.00299383476988",
+  "averageScriptExecutionTime": "262.97526105337266"
+}, {
+  "canonicalDomain": "*.pippio.com",
+  "totalExecutionTime": "92778.8400000003",
+  "totalOccurrences": "808",
+  "totalScripts": "808",
+  "averageExecutionTime": "114.82529702970317",
+  "averageScriptExecutionTime": "114.82529702970317"
+}, {
+  "canonicalDomain": "*.livehelpnow.net",
+  "totalExecutionTime": "235564.65500000006",
+  "totalOccurrences": "805",
+  "totalScripts": "1642",
+  "averageExecutionTime": "292.62690062111767",
+  "averageScriptExecutionTime": "142.92853650103521"
+}, {
+  "canonicalDomain": "*.freetobook.com",
+  "totalExecutionTime": "333886.73999999923",
+  "totalOccurrences": "801",
+  "totalScripts": "974",
+  "averageExecutionTime": "416.83737827715277",
+  "averageScriptExecutionTime": "348.986408947149"
+}, {
+  "canonicalDomain": "*.ekmsecure.com",
+  "totalExecutionTime": "67272.042999999991",
+  "totalOccurrences": "792",
+  "totalScripts": "808",
+  "averageExecutionTime": "84.939448232323173",
+  "averageScriptExecutionTime": "83.938238636363678"
+}, {
+  "canonicalDomain": "*.skype.com",
+  "totalExecutionTime": "154121.93399999823",
+  "totalOccurrences": "772",
+  "totalScripts": "784",
+  "averageExecutionTime": "199.6398108808269",
+  "averageScriptExecutionTime": "197.96953432642297"
+}, {
+  "canonicalDomain": "*.ayads.co",
+  "totalExecutionTime": "309598.9819999992",
+  "totalOccurrences": "764",
+  "totalScripts": "769",
+  "averageExecutionTime": "405.23426963350732",
+  "averageScriptExecutionTime": "403.51646138743382"
+}, {
+  "canonicalDomain": "*.yottaa.com",
+  "totalExecutionTime": "834723.459000001",
+  "totalOccurrences": "763",
+  "totalScripts": "864",
+  "averageExecutionTime": "1094.0019121887281",
+  "averageScriptExecutionTime": "1013.0472337374395"
+}, {
+  "canonicalDomain": "*.tctm.co",
+  "totalExecutionTime": "241735.17399999977",
+  "totalOccurrences": "761",
+  "totalScripts": "1267",
+  "averageExecutionTime": "317.65463074901407",
+  "averageScriptExecutionTime": "168.35226818800444"
+}, {
+  "canonicalDomain": "*.gateway.net",
+  "totalExecutionTime": "47322.077000000034",
+  "totalOccurrences": "756",
+  "totalScripts": "757",
+  "averageExecutionTime": "62.595339947089968",
+  "averageScriptExecutionTime": "62.346315476190519"
+}, {
+  "canonicalDomain": "*.pdst.fm",
+  "totalExecutionTime": "46420.818000000014",
+  "totalOccurrences": "756",
+  "totalScripts": "756",
+  "averageExecutionTime": "61.403198412698387",
+  "averageScriptExecutionTime": "61.403198412698387"
+}, {
+  "canonicalDomain": "*.ad6media.fr",
+  "totalExecutionTime": "920205.256999998",
+  "totalOccurrences": "755",
+  "totalScripts": "3291",
+  "averageExecutionTime": "1218.8149099337725",
+  "averageScriptExecutionTime": "289.778532980132"
+}, {
+  "canonicalDomain": "*.onet.pl",
+  "totalExecutionTime": "434377.05099999951",
+  "totalOccurrences": "748",
+  "totalScripts": "1740",
+  "averageExecutionTime": "580.71798262032144",
+  "averageScriptExecutionTime": "248.39419733256923"
+}, {
+  "canonicalDomain": "*.fam-ad.com",
+  "totalExecutionTime": "2660278.3240000065",
+  "totalOccurrences": "747",
+  "totalScripts": "1232",
+  "averageExecutionTime": "3561.2828969210241",
+  "averageScriptExecutionTime": "2132.8824359660916"
+}, {
+  "canonicalDomain": "*.webmarked.net",
+  "totalExecutionTime": "51070.157999999989",
+  "totalOccurrences": "739",
+  "totalScripts": "751",
+  "averageExecutionTime": "69.1071150202977",
+  "averageScriptExecutionTime": "67.172138024357281"
+}, {
+  "canonicalDomain": "*.navdmp.com",
+  "totalExecutionTime": "49062.848000000013",
+  "totalOccurrences": "731",
+  "totalScripts": "857",
+  "averageExecutionTime": "67.117439124486935",
+  "averageScriptExecutionTime": "56.643283173734588"
+}, {
+  "canonicalDomain": "*.admixer.net",
+  "totalExecutionTime": "878437.05899999687",
+  "totalOccurrences": "721",
+  "totalScripts": "1514",
+  "averageExecutionTime": "1218.3593051317578",
+  "averageScriptExecutionTime": "548.18759667128745"
+}, {
+  "canonicalDomain": "*.urbanairship.com",
+  "totalExecutionTime": "101215.59399999992",
+  "totalOccurrences": "717",
+  "totalScripts": "718",
+  "averageExecutionTime": "141.16540306834037",
+  "averageScriptExecutionTime": "140.99301882845188"
+}, {
+  "canonicalDomain": "*.ad4m.at",
+  "totalExecutionTime": "128175.70900000006",
+  "totalOccurrences": "708",
+  "totalScripts": "1026",
+  "averageExecutionTime": "181.03913700564993",
+  "averageScriptExecutionTime": "125.4598781779662"
+}, {
+  "canonicalDomain": "*.curalate.com",
+  "totalExecutionTime": "651264.01399999892",
+  "totalOccurrences": "706",
+  "totalScripts": "1025",
+  "averageExecutionTime": "922.47027478753273",
+  "averageScriptExecutionTime": "584.65475665722238"
+}, {
+  "canonicalDomain": "*.admatic.com.tr",
+  "totalExecutionTime": "2100203.8539999938",
+  "totalOccurrences": "705",
+  "totalScripts": "2003",
+  "averageExecutionTime": "2979.0125588652409",
+  "averageScriptExecutionTime": "1062.3866047112413"
+}, {
+  "canonicalDomain": "*.decibelinsight.net",
+  "totalExecutionTime": "866311.0919999996",
+  "totalOccurrences": "691",
+  "totalScripts": "693",
+  "averageExecutionTime": "1253.7063560057879",
+  "averageScriptExecutionTime": "1252.5167083936312"
+}, {
+  "canonicalDomain": "*.okasconcepts.com",
+  "totalExecutionTime": "1508180.7230000005",
+  "totalOccurrences": "686",
+  "totalScripts": "904",
+  "averageExecutionTime": "2198.5141734693866",
+  "averageScriptExecutionTime": "2157.7904303449932"
+}, {
+  "canonicalDomain": "*.useinsider.com",
+  "totalExecutionTime": "498483.43699999893",
+  "totalOccurrences": "682",
+  "totalScripts": "978",
+  "averageExecutionTime": "730.9141304985319",
+  "averageScriptExecutionTime": "496.58822002688021"
+}, {
+  "canonicalDomain": "*.ec-concier.com",
+  "totalExecutionTime": "211994.32100000003",
+  "totalOccurrences": "680",
+  "totalScripts": "1417",
+  "averageExecutionTime": "311.75635441176451",
+  "averageScriptExecutionTime": "149.49820490196066"
+}, {
+  "canonicalDomain": "*.monetate.net",
+  "totalExecutionTime": "244548.54099999991",
+  "totalOccurrences": "674",
+  "totalScripts": "1435",
+  "averageExecutionTime": "362.83166320474731",
+  "averageScriptExecutionTime": "138.31317880203108"
+}, {
+  "canonicalDomain": "wwwimages.adobe.com",
+  "totalExecutionTime": "601344.44500018342",
+  "totalOccurrences": "662",
+  "totalScripts": "841",
+  "averageExecutionTime": "908.37529456221228",
+  "averageScriptExecutionTime": "621.68648169707615"
+}, {
+  "canonicalDomain": "*.adscale.de",
+  "totalExecutionTime": "81022.5089999999",
+  "totalOccurrences": "659",
+  "totalScripts": "842",
+  "averageExecutionTime": "122.94766160849753",
+  "averageScriptExecutionTime": "99.309248861911826"
+}, {
+  "canonicalDomain": "*.cookiereports.com",
+  "totalExecutionTime": "263509.16999999975",
+  "totalOccurrences": "652",
+  "totalScripts": "919",
+  "averageExecutionTime": "404.15516871165568",
+  "averageScriptExecutionTime": "302.71823977505085"
+}, {
+  "canonicalDomain": "*.mathjax.org",
+  "totalExecutionTime": "83772.361000000019",
+  "totalOccurrences": "652",
+  "totalScripts": "653",
+  "averageExecutionTime": "128.48521625766878",
+  "averageScriptExecutionTime": "128.24803220858897"
+}, {
+  "canonicalDomain": "*.talkable.com",
+  "totalExecutionTime": "161224.21800000031",
+  "totalOccurrences": "651",
+  "totalScripts": "1044",
+  "averageExecutionTime": "247.65624884792652",
+  "averageScriptExecutionTime": "145.89984575012832"
+}, {
+  "canonicalDomain": "*.clickdesk.com",
+  "totalExecutionTime": "72743.053",
+  "totalOccurrences": "642",
+  "totalScripts": "654",
+  "averageExecutionTime": "113.30693613707166",
+  "averageScriptExecutionTime": "111.42728271028027"
+}, {
+  "canonicalDomain": "*.sharethrough.com",
+  "totalExecutionTime": "99563.045999999522",
+  "totalOccurrences": "641",
+  "totalScripts": "664",
+  "averageExecutionTime": "155.324564742589",
+  "averageScriptExecutionTime": "149.62741653666089"
+}, {
+  "canonicalDomain": "d31y97ze264gaa.cloudfront.net",
+  "totalExecutionTime": "35864.924999999996",
+  "totalOccurrences": "639",
+  "totalScripts": "641",
+  "averageExecutionTime": "56.126643192488288",
+  "averageScriptExecutionTime": "55.962069379238429"
+}, {
+  "canonicalDomain": "*.foxycart.com",
+  "totalExecutionTime": "322845.00599999988",
+  "totalOccurrences": "638",
+  "totalScripts": "826",
+  "averageExecutionTime": "506.02665517241371",
+  "averageScriptExecutionTime": "419.94147178683329"
+}, {
+  "canonicalDomain": "*.salesloft.com",
+  "totalExecutionTime": "30817.936999999984",
+  "totalOccurrences": "626",
+  "totalScripts": "626",
+  "averageExecutionTime": "49.2299313099042",
+  "averageScriptExecutionTime": "49.2299313099042"
+}, {
+  "canonicalDomain": "satori.segs.jp",
+  "totalExecutionTime": "44039.090999999986",
+  "totalOccurrences": "619",
+  "totalScripts": "635",
+  "averageExecutionTime": "71.145542810985461",
+  "averageScriptExecutionTime": "69.300786752827278"
+}, {
+  "canonicalDomain": "*.bfmio.com",
+  "totalExecutionTime": "5197.1560000000027",
+  "totalOccurrences": "604",
+  "totalScripts": "604",
+  "averageExecutionTime": "8.6045629139072979",
+  "averageScriptExecutionTime": "8.6045629139072979"
+}, {
+  "canonicalDomain": "*.exoclick.com",
+  "totalExecutionTime": "57666.172999999886",
+  "totalOccurrences": "593",
+  "totalScripts": "964",
+  "averageExecutionTime": "97.244811129848188",
+  "averageScriptExecutionTime": "55.916726194491254"
+}, {
+  "canonicalDomain": "*.crisp.chat",
+  "totalExecutionTime": "17552.136999999995",
+  "totalOccurrences": "588",
+  "totalScripts": "658",
+  "averageExecutionTime": "29.85057312925171",
+  "averageScriptExecutionTime": "20.9400503117914"
+}, {
+  "canonicalDomain": "*.wigzo.com",
+  "totalExecutionTime": "305271.63699999964",
+  "totalOccurrences": "581",
+  "totalScripts": "661",
+  "averageExecutionTime": "525.424504302925",
+  "averageScriptExecutionTime": "480.28241656421528"
+}, {
+  "canonicalDomain": "*.myregistry.com",
+  "totalExecutionTime": "139772.20799999998",
+  "totalOccurrences": "576",
+  "totalScripts": "846",
+  "averageExecutionTime": "242.66008333333326",
+  "averageScriptExecutionTime": "157.69388859953713"
+}, {
+  "canonicalDomain": "*.connatix.com",
+  "totalExecutionTime": "1122466.9399999944",
+  "totalOccurrences": "572",
+  "totalScripts": "2252",
+  "averageExecutionTime": "1962.35479020978",
+  "averageScriptExecutionTime": "348.5648936516514"
+}, {
+  "canonicalDomain": "*.salesforceliveagent.com",
+  "totalExecutionTime": "93654.936999999816",
+  "totalOccurrences": "566",
+  "totalScripts": "838",
+  "averageExecutionTime": "165.46808657243778",
+  "averageScriptExecutionTime": "97.947495583038673"
+}, {
+  "canonicalDomain": "*.4seeresults.com",
+  "totalExecutionTime": "289102.0619999998",
+  "totalOccurrences": "566",
+  "totalScripts": "1458",
+  "averageExecutionTime": "510.78102826855059",
+  "averageScriptExecutionTime": "167.90759129227661"
+}, {
+  "canonicalDomain": "*.pardot.com",
+  "totalExecutionTime": "73881.691999999908",
+  "totalOccurrences": "550",
+  "totalScripts": "760",
+  "averageExecutionTime": "134.33034909090898",
+  "averageScriptExecutionTime": "90.897104177489012"
+}, {
+  "canonicalDomain": "*.gosquared.com",
+  "totalExecutionTime": "46775.925000000032",
+  "totalOccurrences": "544",
+  "totalScripts": "601",
+  "averageExecutionTime": "85.985156249999918",
+  "averageScriptExecutionTime": "77.7629795955883"
+}, {
+  "canonicalDomain": "*.transifex.com",
+  "totalExecutionTime": "167595.51699999993",
+  "totalOccurrences": "543",
+  "totalScripts": "790",
+  "averageExecutionTime": "308.64736095764226",
+  "averageScriptExecutionTime": "240.557756445672"
+}, {
+  "canonicalDomain": "*.addevent.com",
+  "totalExecutionTime": "92539.48299999992",
+  "totalOccurrences": "541",
+  "totalScripts": "741",
+  "averageExecutionTime": "171.05264879852106",
+  "averageScriptExecutionTime": "80.387155901769091"
+}, {
+  "canonicalDomain": "*.userreport.com",
+  "totalExecutionTime": "144616.7969999999",
+  "totalOccurrences": "538",
+  "totalScripts": "1000",
+  "averageExecutionTime": "268.80445539033423",
+  "averageScriptExecutionTime": "138.95779650380581"
+}, {
+  "canonicalDomain": "*.auth0.com",
+  "totalExecutionTime": "132504.99799999958",
+  "totalOccurrences": "530",
+  "totalScripts": "694",
+  "averageExecutionTime": "250.00943018867861",
+  "averageScriptExecutionTime": "186.25498757861573"
+}, {
+  "canonicalDomain": "*.matheranalytics.com",
+  "totalExecutionTime": "142694.60699999993",
+  "totalOccurrences": "523",
+  "totalScripts": "526",
+  "averageExecutionTime": "272.8386367112812",
+  "averageScriptExecutionTime": "271.75720458890976"
+}, {
+  "canonicalDomain": "*.site24x7rum.com",
+  "totalExecutionTime": "59142.870000000024",
+  "totalOccurrences": "520",
+  "totalScripts": "520",
+  "averageExecutionTime": "113.73628846153851",
+  "averageScriptExecutionTime": "113.73628846153851"
+}, {
+  "canonicalDomain": "*.optnmstr.com",
+  "totalExecutionTime": "99306.1880000021",
+  "totalOccurrences": "506",
+  "totalScripts": "820",
+  "averageExecutionTime": "196.25728853755339",
+  "averageScriptExecutionTime": "77.099036271880621"
+}, {
+  "canonicalDomain": "*.brand-display.com",
+  "totalExecutionTime": "358804.10599999951",
+  "totalOccurrences": "497",
+  "totalScripts": "1026",
+  "averageExecutionTime": "721.9398511066388",
+  "averageScriptExecutionTime": "351.82964442368433"
+}, {
+  "canonicalDomain": "firebasestorage.googleapis.com",
+  "totalExecutionTime": "303242.6200000004",
+  "totalOccurrences": "494",
+  "totalScripts": "501",
+  "averageExecutionTime": "613.85145748987975",
+  "averageScriptExecutionTime": "610.438516801621"
+}, {
+  "canonicalDomain": "*.hubvisor.io",
+  "totalExecutionTime": "388599.07899999805",
+  "totalOccurrences": "493",
+  "totalScripts": "493",
+  "averageExecutionTime": "788.23342596348562",
+  "averageScriptExecutionTime": "788.23342596348562"
+}, {
+  "canonicalDomain": "*.salecycle.com",
+  "totalExecutionTime": "130281.11600000002",
+  "totalOccurrences": "490",
+  "totalScripts": "854",
+  "averageExecutionTime": "265.87982857142873",
+  "averageScriptExecutionTime": "152.08912346938769"
+}, {
+  "canonicalDomain": "*.searchanise.com",
+  "totalExecutionTime": "71057.037999999986",
+  "totalOccurrences": "486",
+  "totalScripts": "486",
+  "averageExecutionTime": "146.20789711934151",
+  "averageScriptExecutionTime": "146.20789711934151"
+}, {
+  "canonicalDomain": "*.usersnap.com",
+  "totalExecutionTime": "368707.01299999916",
+  "totalOccurrences": "486",
+  "totalScripts": "1515",
+  "averageExecutionTime": "758.65640534979286",
+  "averageScriptExecutionTime": "258.41311650499648"
+}, {
+  "canonicalDomain": "*.walkme.com",
+  "totalExecutionTime": "562496.58399999817",
+  "totalOccurrences": "485",
+  "totalScripts": "1826",
+  "averageExecutionTime": "1159.7867711340182",
+  "averageScriptExecutionTime": "237.08770673338057"
+}, {
+  "canonicalDomain": "*.chatwoot.com",
+  "totalExecutionTime": "72095.983",
+  "totalOccurrences": "483",
+  "totalScripts": "702",
+  "averageExecutionTime": "149.26704554865424",
+  "averageScriptExecutionTime": "108.71070065562459"
+}, {
+  "canonicalDomain": "*.knightlab.com",
+  "totalExecutionTime": "448499.20500000339",
+  "totalOccurrences": "475",
+  "totalScripts": "739",
+  "averageExecutionTime": "944.208852631587",
+  "averageScriptExecutionTime": "669.1922489868449"
+}, {
+  "canonicalDomain": "*.popads.net",
+  "totalExecutionTime": "750372.00199999439",
+  "totalOccurrences": "474",
+  "totalScripts": "474",
+  "averageExecutionTime": "1583.0632953586392",
+  "averageScriptExecutionTime": "1583.0632953586392"
+}, {
+  "canonicalDomain": "*.dailykarma.io",
+  "totalExecutionTime": "101657.42599999999",
+  "totalOccurrences": "470",
+  "totalScripts": "812",
+  "averageExecutionTime": "216.2923957446809",
+  "averageScriptExecutionTime": "110.85712879432621"
+}, {
+  "canonicalDomain": "*.flickr.com",
+  "totalExecutionTime": "211178.74200000076",
+  "totalOccurrences": "469",
+  "totalScripts": "902",
+  "averageExecutionTime": "450.2745031982958",
+  "averageScriptExecutionTime": "204.8283994163067"
+}, {
+  "canonicalDomain": "*.viafoura.co",
+  "totalExecutionTime": "316556.86799999961",
+  "totalOccurrences": "468",
+  "totalScripts": "771",
+  "averageExecutionTime": "676.40356410256265",
+  "averageScriptExecutionTime": "310.02980351037809"
+}, {
+  "canonicalDomain": "*.steelhousemedia.com",
+  "totalExecutionTime": "76651.17399999997",
+  "totalOccurrences": "465",
+  "totalScripts": "529",
+  "averageExecutionTime": "164.84123440860202",
+  "averageScriptExecutionTime": "142.25500806451603"
+}, {
+  "canonicalDomain": "*.adition.com",
+  "totalExecutionTime": "59424.693999999967",
+  "totalOccurrences": "461",
+  "totalScripts": "588",
+  "averageExecutionTime": "128.90389154013025",
+  "averageScriptExecutionTime": "101.73867342733185"
+}, {
+  "canonicalDomain": "*.wickedreports.com",
+  "totalExecutionTime": "134796.4870000006",
+  "totalOccurrences": "447",
+  "totalScripts": "450",
+  "averageExecutionTime": "301.5581364653255",
+  "averageScriptExecutionTime": "300.61727181208147"
+}, {
+  "canonicalDomain": "*.sooqr.com",
+  "totalExecutionTime": "175515.7429999997",
+  "totalOccurrences": "445",
+  "totalScripts": "529",
+  "averageExecutionTime": "394.41739999999953",
+  "averageScriptExecutionTime": "346.67581235955004"
+}, {
+  "canonicalDomain": "*.ssl-images-amazon.com",
+  "totalExecutionTime": "219917.1490000021",
+  "totalOccurrences": "440",
+  "totalScripts": "770",
+  "averageExecutionTime": "499.811702272732",
+  "averageScriptExecutionTime": "269.318563966452"
+}, {
+  "canonicalDomain": "*.celtra.com",
+  "totalExecutionTime": "352186.01299999881",
+  "totalOccurrences": "439",
+  "totalScripts": "913",
+  "averageExecutionTime": "802.24604328018",
+  "averageScriptExecutionTime": "398.8189657410411"
+}, {
+  "canonicalDomain": "*.freespee.com",
+  "totalExecutionTime": "55345.401000000042",
+  "totalOccurrences": "430",
+  "totalScripts": "430",
+  "averageExecutionTime": "128.7102348837208",
+  "averageScriptExecutionTime": "128.7102348837208"
+}, {
+  "canonicalDomain": "*.printfriendly.com",
+  "totalExecutionTime": "50879.061000000096",
+  "totalOccurrences": "430",
+  "totalScripts": "431",
+  "averageExecutionTime": "118.32339767441869",
+  "averageScriptExecutionTime": "118.26086395348845"
+}, {
+  "canonicalDomain": "*.ebis.ne.jp",
+  "totalExecutionTime": "31185.451999999881",
+  "totalOccurrences": "429",
+  "totalScripts": "437",
+  "averageExecutionTime": "72.6933613053611",
+  "averageScriptExecutionTime": "71.230644522144317"
+}, {
+  "canonicalDomain": "*.tns-counter.ru",
+  "totalExecutionTime": "48010.871999999974",
+  "totalOccurrences": "429",
+  "totalScripts": "429",
+  "averageExecutionTime": "111.91345454545451",
+  "averageScriptExecutionTime": "111.91345454545451"
+}, {
+  "canonicalDomain": "*.prfct.co",
+  "totalExecutionTime": "31269.697999999989",
+  "totalOccurrences": "428",
+  "totalScripts": "460",
+  "averageExecutionTime": "73.060042056074792",
+  "averageScriptExecutionTime": "68.683695872274157"
+}, {
+  "canonicalDomain": "*.nyltx.com",
+  "totalExecutionTime": "40376.642999999975",
+  "totalOccurrences": "425",
+  "totalScripts": "586",
+  "averageExecutionTime": "95.003865882352912",
+  "averageScriptExecutionTime": "65.9001898039215"
+}, {
+  "canonicalDomain": "*.burstnet.com",
+  "totalExecutionTime": "48.041000000000025",
+  "totalOccurrences": "423",
+  "totalScripts": "424",
+  "averageExecutionTime": "0.11357210401891256",
+  "averageScriptExecutionTime": "0.11357210401891256"
+}, {
+  "canonicalDomain": "*.pubperf.com",
+  "totalExecutionTime": "53454.505000000012",
+  "totalOccurrences": "423",
+  "totalScripts": "423",
+  "averageExecutionTime": "126.36998817966901",
+  "averageScriptExecutionTime": "126.36998817966901"
+}, {
+  "canonicalDomain": "*.adalyser.com",
+  "totalExecutionTime": "31599.428000000014",
+  "totalOccurrences": "420",
+  "totalScripts": "420",
+  "averageExecutionTime": "75.236733333333362",
+  "averageScriptExecutionTime": "75.236733333333362"
+}, {
+  "canonicalDomain": "plus.google.com",
+  "totalExecutionTime": "48386.07099999996",
+  "totalOccurrences": "412",
+  "totalScripts": "413",
+  "averageExecutionTime": "117.44191990291257",
+  "averageScriptExecutionTime": "117.2919162621359"
+}, {
+  "canonicalDomain": "*.siftscience.com",
+  "totalExecutionTime": "105778.36799999951",
+  "totalOccurrences": "411",
+  "totalScripts": "411",
+  "averageExecutionTime": "257.368291970802",
+  "averageScriptExecutionTime": "257.368291970802"
+}, {
+  "canonicalDomain": "*.receiptful.com",
+  "totalExecutionTime": "57660.050999999927",
+  "totalOccurrences": "410",
+  "totalScripts": "460",
+  "averageExecutionTime": "140.6342707317072",
+  "averageScriptExecutionTime": "125.39106951219523"
+}, {
+  "canonicalDomain": "*.wbtrk.net",
+  "totalExecutionTime": "81984.275999999882",
+  "totalOccurrences": "409",
+  "totalScripts": "414",
+  "averageExecutionTime": "200.45055256723703",
+  "averageScriptExecutionTime": "197.57729339853276"
+}, {
+  "canonicalDomain": "*.snack-media.com",
+  "totalExecutionTime": "406372.87599999749",
+  "totalOccurrences": "408",
+  "totalScripts": "728",
+  "averageExecutionTime": "996.01195098038568",
+  "averageScriptExecutionTime": "560.517031454245"
+}, {
+  "canonicalDomain": "*.statuspage.io",
+  "totalExecutionTime": "10809.433000000003",
+  "totalOccurrences": "406",
+  "totalScripts": "409",
+  "averageExecutionTime": "26.624219211822666",
+  "averageScriptExecutionTime": "26.349126847290655"
+}, {
+  "canonicalDomain": "*.flipdesk.jp",
+  "totalExecutionTime": "294750.44799999963",
+  "totalOccurrences": "390",
+  "totalScripts": "767",
+  "averageExecutionTime": "755.77037948717839",
+  "averageScriptExecutionTime": "381.81569145299062"
+}, {
+  "canonicalDomain": "www.sc.pages01.net",
+  "totalExecutionTime": "26894.787",
+  "totalOccurrences": "384",
+  "totalScripts": "384",
+  "averageExecutionTime": "70.038507812500015",
+  "averageScriptExecutionTime": "70.038507812500015"
+}, {
+  "canonicalDomain": "*.adhigh.net",
+  "totalExecutionTime": "1778.886000000002",
+  "totalOccurrences": "382",
+  "totalScripts": "433",
+  "averageExecutionTime": "4.6567696335078548",
+  "averageScriptExecutionTime": "2.7075170157068063"
+}, {
+  "canonicalDomain": "*.pcapredict.com",
+  "totalExecutionTime": "78184.728",
+  "totalOccurrences": "380",
+  "totalScripts": "424",
+  "averageExecutionTime": "205.74928421052661",
+  "averageScriptExecutionTime": "180.21591271929839"
+}, {
+  "canonicalDomain": "*.nend.net",
+  "totalExecutionTime": "22820.137999999995",
+  "totalOccurrences": "378",
+  "totalScripts": "378",
+  "averageExecutionTime": "60.370735449735456",
+  "averageScriptExecutionTime": "60.370735449735456"
+}, {
+  "canonicalDomain": "*.mathads.com",
+  "totalExecutionTime": "32653.87999999999",
+  "totalOccurrences": "378",
+  "totalScripts": "444",
+  "averageExecutionTime": "86.385925925925974",
+  "averageScriptExecutionTime": "75.105246913580231"
+}, {
+  "canonicalDomain": "*.weborama.com",
+  "totalExecutionTime": "30132.112999999998",
+  "totalOccurrences": "377",
+  "totalScripts": "424",
+  "averageExecutionTime": "79.926029177718831",
+  "averageScriptExecutionTime": "63.903713969938089"
+}, {
+  "canonicalDomain": "*.norton.com",
+  "totalExecutionTime": "97547.332999999766",
+  "totalOccurrences": "374",
+  "totalScripts": "728",
+  "averageExecutionTime": "260.82174598930419",
+  "averageScriptExecutionTime": "156.38101626559668"
+}, {
+  "canonicalDomain": "*.giphy.com",
+  "totalExecutionTime": "383116.82000000164",
+  "totalOccurrences": "373",
+  "totalScripts": "964",
+  "averageExecutionTime": "1027.1228418230619",
+  "averageScriptExecutionTime": "374.04560297592525"
+}, {
+  "canonicalDomain": "*.gladly.com",
+  "totalExecutionTime": "199433.05999999936",
+  "totalOccurrences": "371",
+  "totalScripts": "670",
+  "averageExecutionTime": "537.555417789756",
+  "averageScriptExecutionTime": "309.4679539532786"
+}, {
+  "canonicalDomain": "*.pbbl.co",
+  "totalExecutionTime": "57001.610999999924",
+  "totalOccurrences": "369",
+  "totalScripts": "665",
+  "averageExecutionTime": "154.47591056910539",
+  "averageScriptExecutionTime": "84.820222222222114"
+}, {
+  "canonicalDomain": "*.zeotap.com",
+  "totalExecutionTime": "52068.289000000004",
+  "totalOccurrences": "366",
+  "totalScripts": "373",
+  "averageExecutionTime": "142.2630846994534",
+  "averageScriptExecutionTime": "139.92851092896174"
+}, {
+  "canonicalDomain": "*.webkul.com",
+  "totalExecutionTime": "106519.82900000116",
+  "totalOccurrences": "363",
+  "totalScripts": "418",
+  "averageExecutionTime": "293.4430550964222",
+  "averageScriptExecutionTime": "211.43277851239856"
+}, {
+  "canonicalDomain": "*.pixlee.com",
+  "totalExecutionTime": "128306.70799999988",
+  "totalOccurrences": "358",
+  "totalScripts": "373",
+  "averageExecutionTime": "358.3986256983236",
+  "averageScriptExecutionTime": "345.53153770949683"
+}, {
+  "canonicalDomain": "*.de17a.com",
+  "totalExecutionTime": "45889.780000000028",
+  "totalOccurrences": "357",
+  "totalScripts": "602",
+  "averageExecutionTime": "128.54280112044816",
+  "averageScriptExecutionTime": "73.174541549953318"
+}, {
+  "canonicalDomain": "*.concert.io",
+  "totalExecutionTime": "261458.45199999973",
+  "totalOccurrences": "354",
+  "totalScripts": "586",
+  "averageExecutionTime": "738.58319774011193",
+  "averageScriptExecutionTime": "468.31773022598827"
+}, {
+  "canonicalDomain": "*.advertserve.com",
+  "totalExecutionTime": "72028.84399999991",
+  "totalOccurrences": "353",
+  "totalScripts": "616",
+  "averageExecutionTime": "204.04771671388076",
+  "averageScriptExecutionTime": "111.93735666846516"
+}, {
+  "canonicalDomain": "*.omniconvert.com",
+  "totalExecutionTime": "76587.729000000021",
+  "totalOccurrences": "352",
+  "totalScripts": "352",
+  "averageExecutionTime": "217.57877556818184",
+  "averageScriptExecutionTime": "217.57877556818184"
+}, {
+  "canonicalDomain": "*.typography.com",
+  "totalExecutionTime": "1.8310000000000002",
+  "totalOccurrences": "352",
+  "totalScripts": "352",
+  "averageExecutionTime": "0.0052017045454545441",
+  "averageScriptExecutionTime": "0.0052017045454545441"
+}, {
+  "canonicalDomain": "*.spot.im",
+  "totalExecutionTime": "202862.40199999933",
+  "totalOccurrences": "351",
+  "totalScripts": "991",
+  "averageExecutionTime": "577.95556125355938",
+  "averageScriptExecutionTime": "206.55335446343702"
+}, {
+  "canonicalDomain": "*.qualaroo.com",
+  "totalExecutionTime": "45400.482999999971",
+  "totalOccurrences": "349",
+  "totalScripts": "355",
+  "averageExecutionTime": "130.08734383954135",
+  "averageScriptExecutionTime": "127.70029369627498"
+}, {
+  "canonicalDomain": "*.silktide.com",
+  "totalExecutionTime": "123212.88800000059",
+  "totalOccurrences": "346",
+  "totalScripts": "348",
+  "averageExecutionTime": "356.10661271676406",
+  "averageScriptExecutionTime": "354.83032947976994"
+}, {
+  "canonicalDomain": "*.skyscanner.net",
+  "totalExecutionTime": "81648.253999999972",
+  "totalOccurrences": "346",
+  "totalScripts": "349",
+  "averageExecutionTime": "235.97761271676296",
+  "averageScriptExecutionTime": "234.82076589595374"
+}, {
+  "canonicalDomain": "*.dpmsrv.com",
+  "totalExecutionTime": "721050.51400000043",
+  "totalOccurrences": "345",
+  "totalScripts": "349",
+  "averageExecutionTime": "2090.0014898550735",
+  "averageScriptExecutionTime": "2079.4437768115959"
+}, {
+  "canonicalDomain": "*.vox-cdn.com",
+  "totalExecutionTime": "606010.81299999868",
+  "totalOccurrences": "345",
+  "totalScripts": "1225",
+  "averageExecutionTime": "1756.5530811594158",
+  "averageScriptExecutionTime": "496.82441058661044"
+}, {
+  "canonicalDomain": "*.photobucket.com",
+  "totalExecutionTime": "74662.337000000174",
+  "totalOccurrences": "344",
+  "totalScripts": "360",
+  "averageExecutionTime": "217.04167732558238",
+  "averageScriptExecutionTime": "170.6219637320045"
+}, {
+  "canonicalDomain": "*.bannersnack.com",
+  "totalExecutionTime": "189596.06899999964",
+  "totalOccurrences": "341",
+  "totalScripts": "1039",
+  "averageExecutionTime": "556.0002023460404",
+  "averageScriptExecutionTime": "160.06021297546519"
+}, {
+  "canonicalDomain": "*.scupio.com",
+  "totalExecutionTime": "54005.965999999986",
+  "totalOccurrences": "340",
+  "totalScripts": "460",
+  "averageExecutionTime": "158.84107647058821",
+  "averageScriptExecutionTime": "121.41533941176471"
+}, {
+  "canonicalDomain": "*.serverbid.com",
+  "totalExecutionTime": "21854.553000000004",
+  "totalOccurrences": "338",
+  "totalScripts": "339",
+  "averageExecutionTime": "64.658440828402348",
+  "averageScriptExecutionTime": "64.599331360946763"
+}, {
+  "canonicalDomain": "*.thcdn.com",
+  "totalExecutionTime": "512304.9679999997",
+  "totalOccurrences": "335",
+  "totalScripts": "2192",
+  "averageExecutionTime": "1529.2685611940285",
+  "averageScriptExecutionTime": "223.59366451635404"
+}, {
+  "canonicalDomain": "*.searchspring.net",
+  "totalExecutionTime": "1216402.1100000143",
+  "totalOccurrences": "331",
+  "totalScripts": "999",
+  "averageExecutionTime": "3674.9308459214953",
+  "averageScriptExecutionTime": "1147.148325636618"
+}, {
+  "canonicalDomain": "*.securedvisit.com",
+  "totalExecutionTime": "36733.047999999959",
+  "totalOccurrences": "326",
+  "totalScripts": "347",
+  "averageExecutionTime": "112.67806134969321",
+  "averageScriptExecutionTime": "103.51601610429441"
+}, {
+  "canonicalDomain": "*.opta.net",
+  "totalExecutionTime": "358706.83999999979",
+  "totalOccurrences": "326",
+  "totalScripts": "1068",
+  "averageExecutionTime": "1100.32773006135",
+  "averageScriptExecutionTime": "307.25722822085868"
+}, {
+  "canonicalDomain": "d22xmn10vbouk4.cloudfront.net",
+  "totalExecutionTime": "91884.746999999436",
+  "totalOccurrences": "321",
+  "totalScripts": "321",
+  "averageExecutionTime": "286.24531775700774",
+  "averageScriptExecutionTime": "286.24531775700774"
+}, {
+  "canonicalDomain": "*.deepintent.com",
+  "totalExecutionTime": "629.70800000000008",
+  "totalOccurrences": "320",
+  "totalScripts": "320",
+  "averageExecutionTime": "1.9678375000000001",
+  "averageScriptExecutionTime": "1.9678375000000001"
+}, {
+  "canonicalDomain": "*.freshrelevance.com",
+  "totalExecutionTime": "86859.820999999953",
+  "totalOccurrences": "317",
+  "totalScripts": "496",
+  "averageExecutionTime": "274.00574447949504",
+  "averageScriptExecutionTime": "179.06086750788614"
+}, {
+  "canonicalDomain": "*.bidtheatre.com",
+  "totalExecutionTime": "18445.293000000009",
+  "totalOccurrences": "313",
+  "totalScripts": "320",
+  "averageExecutionTime": "58.93064856230037",
+  "averageScriptExecutionTime": "57.479105963791262"
+}, {
+  "canonicalDomain": "*.exelator.com",
+  "totalExecutionTime": "22357.245000000003",
+  "totalOccurrences": "311",
+  "totalScripts": "312",
+  "averageExecutionTime": "71.888247588424434",
+  "averageScriptExecutionTime": "71.5407540192926"
+}, {
+  "canonicalDomain": "*.rkdms.com",
+  "totalExecutionTime": "45474.312999999987",
+  "totalOccurrences": "310",
+  "totalScripts": "310",
+  "averageExecutionTime": "146.69133225806451",
+  "averageScriptExecutionTime": "146.69133225806451"
+}, {
+  "canonicalDomain": "*.ordergroove.com",
+  "totalExecutionTime": "86764.093000009641",
+  "totalOccurrences": "305",
+  "totalScripts": "312",
+  "averageExecutionTime": "284.47243606560551",
+  "averageScriptExecutionTime": "280.8869688524909"
+}, {
+  "canonicalDomain": "*.pcrl.co",
+  "totalExecutionTime": "43663.567999999745",
+  "totalOccurrences": "304",
+  "totalScripts": "354",
+  "averageExecutionTime": "143.63015789473616",
+  "averageScriptExecutionTime": "126.5998486842099"
+}, {
+  "canonicalDomain": "*.emsecure.net",
+  "totalExecutionTime": "64098.555",
+  "totalOccurrences": "301",
+  "totalScripts": "434",
+  "averageExecutionTime": "212.95200996677733",
+  "averageScriptExecutionTime": "152.7817901439646"
+}, {
+  "canonicalDomain": "*.cdn-net.com",
+  "totalExecutionTime": "277814.08399999805",
+  "totalOccurrences": "299",
+  "totalScripts": "299",
+  "averageExecutionTime": "929.14409364547873",
+  "averageScriptExecutionTime": "929.14409364547873"
+}, {
+  "canonicalDomain": "*.adinsight.com",
+  "totalExecutionTime": "78262.0139999999",
+  "totalOccurrences": "292",
+  "totalScripts": "350",
+  "averageExecutionTime": "268.02059589041056",
+  "averageScriptExecutionTime": "222.0924931506845"
+}, {
+  "canonicalDomain": "*.opentok.com",
+  "totalExecutionTime": "191502.18399999948",
+  "totalOccurrences": "292",
+  "totalScripts": "292",
+  "averageExecutionTime": "655.82939726027246",
+  "averageScriptExecutionTime": "655.82939726027246"
+}, {
+  "canonicalDomain": "*.mailplus.nl",
+  "totalExecutionTime": "82173.6999999999",
+  "totalOccurrences": "290",
+  "totalScripts": "485",
+  "averageExecutionTime": "283.35758620689643",
+  "averageScriptExecutionTime": "156.77088770114938"
+}, {
+  "canonicalDomain": "*.inside-graph.com",
+  "totalExecutionTime": "167782.90799999982",
+  "totalOccurrences": "290",
+  "totalScripts": "620",
+  "averageExecutionTime": "578.56175172413793",
+  "averageScriptExecutionTime": "262.58541270114921"
+}, {
+  "canonicalDomain": "*.performax.cz",
+  "totalExecutionTime": "108366.25899999947",
+  "totalOccurrences": "289",
+  "totalScripts": "438",
+  "averageExecutionTime": "374.96975432525755",
+  "averageScriptExecutionTime": "229.4705354671259"
+}, {
+  "canonicalDomain": "*.optimove.net",
+  "totalExecutionTime": "24550.181000000008",
+  "totalOccurrences": "288",
+  "totalScripts": "302",
+  "averageExecutionTime": "85.243684027777817",
+  "averageScriptExecutionTime": "82.032027199074108"
+}, {
+  "canonicalDomain": "*.advertising.com",
+  "totalExecutionTime": "107773.73799999985",
+  "totalOccurrences": "287",
+  "totalScripts": "462",
+  "averageExecutionTime": "375.51825087107943",
+  "averageScriptExecutionTime": "232.30367453265811"
+}, {
+  "canonicalDomain": "*.connextra.com",
+  "totalExecutionTime": "65595.9609999999",
+  "totalOccurrences": "286",
+  "totalScripts": "320",
+  "averageExecutionTime": "229.35650699300689",
+  "averageScriptExecutionTime": "207.59847027972029"
+}, {
+  "canonicalDomain": "*.sharpspring.com",
+  "totalExecutionTime": "103608.35399999979",
+  "totalOccurrences": "286",
+  "totalScripts": "729",
+  "averageExecutionTime": "362.26697202797186",
+  "averageScriptExecutionTime": "106.03492239982232"
+}, {
+  "canonicalDomain": "*.webcontentassessor.com",
+  "totalExecutionTime": "110504.69499999995",
+  "totalOccurrences": "283",
+  "totalScripts": "290",
+  "averageExecutionTime": "390.47595406360415",
+  "averageScriptExecutionTime": "373.43088515901047"
+}, {
+  "canonicalDomain": "*.aweber.com",
+  "totalExecutionTime": "48200.708000000304",
+  "totalOccurrences": "281",
+  "totalScripts": "286",
+  "averageExecutionTime": "171.53276868327498",
+  "averageScriptExecutionTime": "168.9265587188622"
+}, {
+  "canonicalDomain": "*.litix.io",
+  "totalExecutionTime": "94716.391999999963",
+  "totalOccurrences": "277",
+  "totalScripts": "283",
+  "averageExecutionTime": "341.93643321299623",
+  "averageScriptExecutionTime": "339.06812093862783"
+}, {
+  "canonicalDomain": "*.keywee.co",
+  "totalExecutionTime": "43344.757999999842",
+  "totalOccurrences": "274",
+  "totalScripts": "376",
+  "averageExecutionTime": "158.19254744525503",
+  "averageScriptExecutionTime": "115.99484428223815"
+}, {
+  "canonicalDomain": "*.investis.com",
+  "totalExecutionTime": "199531.06900000127",
+  "totalOccurrences": "272",
+  "totalScripts": "573",
+  "averageExecutionTime": "733.57010661765116",
+  "averageScriptExecutionTime": "180.20294350052637"
+}, {
+  "canonicalDomain": "*.keen.io",
+  "totalExecutionTime": "21736.933999999932",
+  "totalOccurrences": "268",
+  "totalScripts": "269",
+  "averageExecutionTime": "81.107962686566935",
+  "averageScriptExecutionTime": "77.811069029850586"
+}, {
+  "canonicalDomain": "*.cdngc.net",
+  "totalExecutionTime": "263695.54199999449",
+  "totalOccurrences": "268",
+  "totalScripts": "603",
+  "averageExecutionTime": "983.93858955221924",
+  "averageScriptExecutionTime": "436.13154477611056"
+}, {
+  "canonicalDomain": "*.360yield.com",
+  "totalExecutionTime": "17025.609000000019",
+  "totalOccurrences": "266",
+  "totalScripts": "269",
+  "averageExecutionTime": "64.006048872180486",
+  "averageScriptExecutionTime": "63.2436259398497"
+}, {
+  "canonicalDomain": "*.rezync.com",
+  "totalExecutionTime": "24185.690999999933",
+  "totalOccurrences": "265",
+  "totalScripts": "289",
+  "averageExecutionTime": "91.266758490565834",
+  "averageScriptExecutionTime": "81.199662578616156"
+}, {
+  "canonicalDomain": "*.gleam.io",
+  "totalExecutionTime": "74466.348999999871",
+  "totalOccurrences": "263",
+  "totalScripts": "328",
+  "averageExecutionTime": "283.14201140684355",
+  "averageScriptExecutionTime": "194.9486486058299"
+}, {
+  "canonicalDomain": "*.underdog.media",
+  "totalExecutionTime": "752240.28799999668",
+  "totalOccurrences": "263",
+  "totalScripts": "1147",
+  "averageExecutionTime": "2860.2292319391472",
+  "averageScriptExecutionTime": "711.94459759860524"
+}, {
+  "canonicalDomain": "*.appmate.io",
+  "totalExecutionTime": "124630.34999999992",
+  "totalOccurrences": "261",
+  "totalScripts": "481",
+  "averageExecutionTime": "477.51091954022957",
+  "averageScriptExecutionTime": "247.04940804597675"
+}, {
+  "canonicalDomain": "*.clickdimensions.com",
+  "totalExecutionTime": "80026.575000000666",
+  "totalOccurrences": "251",
+  "totalScripts": "438",
+  "averageExecutionTime": "318.8309760956202",
+  "averageScriptExecutionTime": "179.84977403718574"
+}, {
+  "canonicalDomain": "d36mpcpuzc4ztk.cloudfront.net",
+  "totalExecutionTime": "65105.962999999763",
+  "totalOccurrences": "250",
+  "totalScripts": "250",
+  "averageExecutionTime": "260.4238519999991",
+  "averageScriptExecutionTime": "260.4238519999991"
+}, {
+  "canonicalDomain": "*.agkn.com",
+  "totalExecutionTime": "12780.115000000011",
+  "totalOccurrences": "248",
+  "totalScripts": "256",
+  "averageExecutionTime": "51.53272177419359",
+  "averageScriptExecutionTime": "50.944645161290332"
+}, {
+  "canonicalDomain": "dcniko1cv0rz.cloudfront.net",
+  "totalExecutionTime": "31983.864000000005",
+  "totalOccurrences": "247",
+  "totalScripts": "247",
+  "averageExecutionTime": "129.48932793522266",
+  "averageScriptExecutionTime": "129.48932793522266"
+}, {
+  "canonicalDomain": "*.sajari.com",
+  "totalExecutionTime": "76456.115999999849",
+  "totalOccurrences": "244",
+  "totalScripts": "269",
+  "averageExecutionTime": "313.34473770491729",
+  "averageScriptExecutionTime": "273.74497745901596"
+}, {
+  "canonicalDomain": "*.hupso.com",
+  "totalExecutionTime": "18090.621999999996",
+  "totalOccurrences": "243",
+  "totalScripts": "243",
+  "averageExecutionTime": "74.447004115226335",
+  "averageScriptExecutionTime": "74.447004115226335"
+}, {
+  "canonicalDomain": "*.yabidos.com",
+  "totalExecutionTime": "31912.412999999993",
+  "totalOccurrences": "243",
+  "totalScripts": "302",
+  "averageExecutionTime": "131.32680246913583",
+  "averageScriptExecutionTime": "105.88316906721538"
+}, {
+  "canonicalDomain": "*.infinity-tracking.net",
+  "totalExecutionTime": "25040.669999999911",
+  "totalOccurrences": "242",
+  "totalScripts": "243",
+  "averageExecutionTime": "103.47384297520625",
+  "averageScriptExecutionTime": "102.68491322314016"
+}, {
+  "canonicalDomain": "*.trackedlink.net",
+  "totalExecutionTime": "19316.439999999991",
+  "totalOccurrences": "241",
+  "totalScripts": "256",
+  "averageExecutionTime": "80.151203319502073",
+  "averageScriptExecutionTime": "76.262169778699757"
+}, {
+  "canonicalDomain": "*.builder.io",
+  "totalExecutionTime": "504957.93600000074",
+  "totalOccurrences": "241",
+  "totalScripts": "412",
+  "averageExecutionTime": "2095.2611452282176",
+  "averageScriptExecutionTime": "835.73101023513175"
+}, {
+  "canonicalDomain": "*.bluecore.com",
+  "totalExecutionTime": "89153.301999999763",
+  "totalOccurrences": "236",
+  "totalScripts": "240",
+  "averageExecutionTime": "377.76822881355838",
+  "averageScriptExecutionTime": "368.74439830508385"
+}, {
+  "canonicalDomain": "*.jsrdn.com",
+  "totalExecutionTime": "241197.77099999963",
+  "totalOccurrences": "235",
+  "totalScripts": "639",
+  "averageExecutionTime": "1026.3734936170192",
+  "averageScriptExecutionTime": "322.43235404255273"
+}, {
+  "canonicalDomain": "*.profitshare.ro",
+  "totalExecutionTime": "78839.417999999845",
+  "totalOccurrences": "235",
+  "totalScripts": "449",
+  "averageExecutionTime": "335.48688510638232",
+  "averageScriptExecutionTime": "192.82556071566714"
+}, {
+  "canonicalDomain": "*.kiosked.com",
+  "totalExecutionTime": "378362.82299999963",
+  "totalOccurrences": "234",
+  "totalScripts": "236",
+  "averageExecutionTime": "1616.9351410256379",
+  "averageScriptExecutionTime": "1609.4565170940145"
+}, {
+  "canonicalDomain": "*.coral.coralproject.net",
+  "totalExecutionTime": "52782.060999999936",
+  "totalOccurrences": "234",
+  "totalScripts": "244",
+  "averageExecutionTime": "225.56436324786293",
+  "averageScriptExecutionTime": "197.00352777777761"
+}, {
+  "canonicalDomain": "*.infogr.am",
+  "totalExecutionTime": "1118379.8970000145",
+  "totalOccurrences": "233",
+  "totalScripts": "737",
+  "averageExecutionTime": "4799.9137210301078",
+  "averageScriptExecutionTime": "1734.8767836984425"
+}, {
+  "canonicalDomain": "*.virtualearth.net",
+  "totalExecutionTime": "78859.803999999931",
+  "totalOccurrences": "233",
+  "totalScripts": "371",
+  "averageExecutionTime": "338.4540944206006",
+  "averageScriptExecutionTime": "164.27317623213708"
+}, {
+  "canonicalDomain": "*.datawrapper.de",
+  "totalExecutionTime": "698701.49500000221",
+  "totalOccurrences": "231",
+  "totalScripts": "1305",
+  "averageExecutionTime": "3024.6817965368055",
+  "averageScriptExecutionTime": "574.21257397683007"
+}, {
+  "canonicalDomain": "*.sstatic.net",
+  "totalExecutionTime": "201973.82899999982",
+  "totalOccurrences": "230",
+  "totalScripts": "1255",
+  "averageExecutionTime": "878.14708260869509",
+  "averageScriptExecutionTime": "159.60521471014488"
+}, {
+  "canonicalDomain": "*.retentionscience.com",
+  "totalExecutionTime": "17888.133",
+  "totalOccurrences": "230",
+  "totalScripts": "230",
+  "averageExecutionTime": "77.7744913043478",
+  "averageScriptExecutionTime": "77.7744913043478"
+}, {
+  "canonicalDomain": "*.yieldify.com",
+  "totalExecutionTime": "609941.375",
+  "totalOccurrences": "227",
+  "totalScripts": "339",
+  "averageExecutionTime": "2686.9664096916304",
+  "averageScriptExecutionTime": "1752.7032606461078"
+}, {
+  "canonicalDomain": "*.cachefly.net",
+  "totalExecutionTime": "65826.7379999999",
+  "totalOccurrences": "225",
+  "totalScripts": "265",
+  "averageExecutionTime": "292.56327999999962",
+  "averageScriptExecutionTime": "235.01217259259246"
+}, {
+  "canonicalDomain": "*.clicktripz.com",
+  "totalExecutionTime": "506830.84599999804",
+  "totalOccurrences": "223",
+  "totalScripts": "562",
+  "averageExecutionTime": "2272.78406278026",
+  "averageScriptExecutionTime": "978.10866649049353"
+}, {
+  "canonicalDomain": "*.polarmobile.ca",
+  "totalExecutionTime": "75178.793999999849",
+  "totalOccurrences": "222",
+  "totalScripts": "232",
+  "averageExecutionTime": "338.64321621621582",
+  "averageScriptExecutionTime": "291.46435435435382"
+}, {
+  "canonicalDomain": "*.3gl.net",
+  "totalExecutionTime": "32834.606999999982",
+  "totalOccurrences": "220",
+  "totalScripts": "220",
+  "averageExecutionTime": "149.24821363636357",
+  "averageScriptExecutionTime": "149.24821363636357"
+}, {
+  "canonicalDomain": "*.bolt.com",
+  "totalExecutionTime": "496378.59400000272",
+  "totalOccurrences": "218",
+  "totalScripts": "802",
+  "averageExecutionTime": "2276.9660275229476",
+  "averageScriptExecutionTime": "496.93532613686216"
+}, {
+  "canonicalDomain": "*.surveymonkey.com",
+  "totalExecutionTime": "11818.158000000005",
+  "totalOccurrences": "217",
+  "totalScripts": "312",
+  "averageExecutionTime": "54.461557603686636",
+  "averageScriptExecutionTime": "39.568943932411692"
+}, {
+  "canonicalDomain": "*.mlveda.com",
+  "totalExecutionTime": "71797.078999997233",
+  "totalOccurrences": "216",
+  "totalScripts": "219",
+  "averageExecutionTime": "332.39388425924619",
+  "averageScriptExecutionTime": "326.56779166665365"
+}, {
+  "canonicalDomain": "*.stackla.com",
+  "totalExecutionTime": "315659.99099999946",
+  "totalOccurrences": "216",
+  "totalScripts": "716",
+  "averageExecutionTime": "1461.3888472222188",
+  "averageScriptExecutionTime": "396.37030372207425"
+}, {
+  "canonicalDomain": "*.ezoic.net",
+  "totalExecutionTime": "156962.17199999985",
+  "totalOccurrences": "215",
+  "totalScripts": "366",
+  "averageExecutionTime": "730.0566139534875",
+  "averageScriptExecutionTime": "344.03249941860361"
+}, {
+  "canonicalDomain": "*.trialfire.com",
+  "totalExecutionTime": "39727.165000000015",
+  "totalOccurrences": "207",
+  "totalScripts": "419",
+  "averageExecutionTime": "191.9186714975846",
+  "averageScriptExecutionTime": "93.077082528180327"
+}, {
+  "canonicalDomain": "*.mediahawk.co.uk",
+  "totalExecutionTime": "54773.641999999971",
+  "totalOccurrences": "207",
+  "totalScripts": "207",
+  "averageExecutionTime": "264.60696618357485",
+  "averageScriptExecutionTime": "264.60696618357485"
+}, {
+  "canonicalDomain": "*.gaug.es",
+  "totalExecutionTime": "10306.397999999994",
+  "totalOccurrences": "205",
+  "totalScripts": "205",
+  "averageExecutionTime": "50.275112195121977",
+  "averageScriptExecutionTime": "50.275112195121977"
+}, {
+  "canonicalDomain": "*.terminus.services",
+  "totalExecutionTime": "28468.005000000005",
+  "totalOccurrences": "205",
+  "totalScripts": "207",
+  "averageExecutionTime": "138.86831707317072",
+  "averageScriptExecutionTime": "138.06799024390244"
+}, {
+  "canonicalDomain": "*.mediarithmics.com",
+  "totalExecutionTime": "29679.445000000007",
+  "totalOccurrences": "204",
+  "totalScripts": "235",
+  "averageExecutionTime": "145.48747549019609",
+  "averageScriptExecutionTime": "127.61892687908488"
+}, {
+  "canonicalDomain": "*.ometria.com",
+  "totalExecutionTime": "13088.381999999992",
+  "totalOccurrences": "201",
+  "totalScripts": "201",
+  "averageExecutionTime": "65.11632835820896",
+  "averageScriptExecutionTime": "65.11632835820896"
+}, {
+  "canonicalDomain": "*.cnstrc.com",
+  "totalExecutionTime": "65611.553999999916",
+  "totalOccurrences": "201",
+  "totalScripts": "208",
+  "averageExecutionTime": "326.42564179104426",
+  "averageScriptExecutionTime": "314.05603482587031"
+}, {
+  "canonicalDomain": "*.200summit.com",
+  "totalExecutionTime": "12809.667000000003",
+  "totalOccurrences": "195",
+  "totalScripts": "195",
+  "averageExecutionTime": "65.6906",
+  "averageScriptExecutionTime": "65.6906"
+}, {
+  "canonicalDomain": "*.speedshiftmedia.com",
+  "totalExecutionTime": "50800.653999999748",
+  "totalOccurrences": "191",
+  "totalScripts": "349",
+  "averageExecutionTime": "265.97201047120285",
+  "averageScriptExecutionTime": "180.97681239092373"
+}, {
+  "canonicalDomain": "*.247realmedia.com",
+  "totalExecutionTime": "15707.533000000009",
+  "totalOccurrences": "186",
+  "totalScripts": "201",
+  "averageExecutionTime": "84.449102150537627",
+  "averageScriptExecutionTime": "72.81583064516127"
+}, {
+  "canonicalDomain": "*.andbeyond.media",
+  "totalExecutionTime": "339926.56700000004",
+  "totalOccurrences": "184",
+  "totalScripts": "277",
+  "averageExecutionTime": "1847.4269945652168",
+  "averageScriptExecutionTime": "1066.8915552536234"
+}, {
+  "canonicalDomain": "*.apester.com",
+  "totalExecutionTime": "27114.962999999927",
+  "totalOccurrences": "180",
+  "totalScripts": "219",
+  "averageExecutionTime": "150.63868333333298",
+  "averageScriptExecutionTime": "90.8416328703703"
+}, {
+  "canonicalDomain": "*.kaizenplatform.net",
+  "totalExecutionTime": "75071.661999999837",
+  "totalOccurrences": "179",
+  "totalScripts": "179",
+  "averageExecutionTime": "419.39475977653535",
+  "averageScriptExecutionTime": "419.39475977653535"
+}, {
+  "canonicalDomain": "d19ayerf5ehaab.cloudfront.net",
+  "totalExecutionTime": "79260.4009999989",
+  "totalOccurrences": "177",
+  "totalScripts": "267",
+  "averageExecutionTime": "447.79887570620821",
+  "averageScriptExecutionTime": "319.77740677965755"
+}, {
+  "canonicalDomain": "*.rutarget.ru",
+  "totalExecutionTime": "6969.5429999999942",
+  "totalOccurrences": "176",
+  "totalScripts": "184",
+  "averageExecutionTime": "39.5996761363636",
+  "averageScriptExecutionTime": "38.358627840909072"
+}, {
+  "canonicalDomain": "*.feedbackify.com",
+  "totalExecutionTime": "40015.365999999871",
+  "totalOccurrences": "175",
+  "totalScripts": "192",
+  "averageExecutionTime": "228.65923428571347",
+  "averageScriptExecutionTime": "215.31945428571359"
+}, {
+  "canonicalDomain": "*.click4assistance.co.uk",
+  "totalExecutionTime": "19221.843999999997",
+  "totalOccurrences": "174",
+  "totalScripts": "223",
+  "averageExecutionTime": "110.47036781609192",
+  "averageScriptExecutionTime": "86.4756063218391"
+}, {
+  "canonicalDomain": "*.filepicker.io",
+  "totalExecutionTime": "24881.335000000006",
+  "totalOccurrences": "174",
+  "totalScripts": "273",
+  "averageExecutionTime": "142.99617816091964",
+  "averageScriptExecutionTime": "90.779418103448279"
+}, {
+  "canonicalDomain": "*.associates-amazon.com",
+  "totalExecutionTime": "8862.9389999999985",
+  "totalOccurrences": "172",
+  "totalScripts": "172",
+  "averageExecutionTime": "51.528715116279066",
+  "averageScriptExecutionTime": "51.528715116279066"
+}, {
+  "canonicalDomain": "*.cmcore.com",
+  "totalExecutionTime": "133659.94399999929",
+  "totalOccurrences": "171",
+  "totalScripts": "432",
+  "averageExecutionTime": "781.6370994152",
+  "averageScriptExecutionTime": "407.06775074450428"
+}, {
+  "canonicalDomain": "*.tp88trk.com",
+  "totalExecutionTime": "106225.47699999994",
+  "totalOccurrences": "171",
+  "totalScripts": "176",
+  "averageExecutionTime": "621.20161988304062",
+  "averageScriptExecutionTime": "605.93072514619848"
+}, {
+  "canonicalDomain": "*.mopinion.com",
+  "totalExecutionTime": "146926.82099999936",
+  "totalOccurrences": "170",
+  "totalScripts": "276",
+  "averageExecutionTime": "864.27541764705506",
+  "averageScriptExecutionTime": "663.04347941176172"
+}, {
+  "canonicalDomain": "*.carbonads.net",
+  "totalExecutionTime": "9344.361",
+  "totalOccurrences": "170",
+  "totalScripts": "171",
+  "averageExecutionTime": "54.966829411764728",
+  "averageScriptExecutionTime": "54.693955882352931"
+}, {
+  "canonicalDomain": "*.confirmit.com",
+  "totalExecutionTime": "22458.533999999963",
+  "totalOccurrences": "166",
+  "totalScripts": "204",
+  "averageExecutionTime": "135.29237349397567",
+  "averageScriptExecutionTime": "88.771759136546052"
+}, {
+  "canonicalDomain": "adobe.com",
+  "totalExecutionTime": "40975.585999999974",
+  "totalOccurrences": "164",
+  "totalScripts": "238",
+  "averageExecutionTime": "249.85113414634134",
+  "averageScriptExecutionTime": "151.24653048780493"
+}, {
+  "canonicalDomain": "*.ibillboard.com",
+  "totalExecutionTime": "64690.769999999749",
+  "totalOccurrences": "163",
+  "totalScripts": "291",
+  "averageExecutionTime": "396.87588957055073",
+  "averageScriptExecutionTime": "236.9509611451933"
+}, {
+  "canonicalDomain": "*.reevoo.com",
+  "totalExecutionTime": "88493.401999999871",
+  "totalOccurrences": "162",
+  "totalScripts": "305",
+  "averageExecutionTime": "546.25556790123369",
+  "averageScriptExecutionTime": "251.64232561728355"
+}, {
+  "canonicalDomain": "*.elasticad.net",
+  "totalExecutionTime": "33023.512000000024",
+  "totalOccurrences": "162",
+  "totalScripts": "282",
+  "averageExecutionTime": "203.84883950617308",
+  "averageScriptExecutionTime": "118.26228086419758"
+}, {
+  "canonicalDomain": "*.friendbuy.com",
+  "totalExecutionTime": "23964.603000000017",
+  "totalOccurrences": "161",
+  "totalScripts": "161",
+  "averageExecutionTime": "148.84846583850936",
+  "averageScriptExecutionTime": "148.84846583850936"
+}, {
+  "canonicalDomain": "*.g2.com",
+  "totalExecutionTime": "96914.119999999937",
+  "totalOccurrences": "158",
+  "totalScripts": "294",
+  "averageExecutionTime": "613.38050632911325",
+  "averageScriptExecutionTime": "242.37567365631872"
+}, {
+  "canonicalDomain": "*.pro-market.net",
+  "totalExecutionTime": "10967.934",
+  "totalOccurrences": "158",
+  "totalScripts": "165",
+  "averageExecutionTime": "69.417303797468335",
+  "averageScriptExecutionTime": "65.072646202531672"
+}, {
+  "canonicalDomain": "*.ad-srv.net",
+  "totalExecutionTime": "6845.5290000000014",
+  "totalOccurrences": "155",
+  "totalScripts": "189",
+  "averageExecutionTime": "44.164703225806441",
+  "averageScriptExecutionTime": "32.68834784946236"
+}, {
+  "canonicalDomain": "*.cludo.com",
+  "totalExecutionTime": "17316.71699999999",
+  "totalOccurrences": "154",
+  "totalScripts": "221",
+  "averageExecutionTime": "112.44621428571428",
+  "averageScriptExecutionTime": "58.9291064935065"
+}, {
+  "canonicalDomain": "*.fqtag.com",
+  "totalExecutionTime": "51039.541000000077",
+  "totalOccurrences": "152",
+  "totalScripts": "306",
+  "averageExecutionTime": "335.78645394736884",
+  "averageScriptExecutionTime": "166.23327796052664"
+}, {
+  "canonicalDomain": "*.fanplayr.com",
+  "totalExecutionTime": "56987.677999999876",
+  "totalOccurrences": "152",
+  "totalScripts": "195",
+  "averageExecutionTime": "374.91893421052549",
+  "averageScriptExecutionTime": "292.943690789473"
+}, {
+  "canonicalDomain": "*.pvnsolutions.com",
+  "totalExecutionTime": "29529.265",
+  "totalOccurrences": "151",
+  "totalScripts": "239",
+  "averageExecutionTime": "195.55804635761575",
+  "averageScriptExecutionTime": "121.04091181015454"
+}, {
+  "canonicalDomain": "getrockerbox.com",
+  "totalExecutionTime": "14309.821000000004",
+  "totalOccurrences": "151",
+  "totalScripts": "180",
+  "averageExecutionTime": "94.767026490066215",
+  "averageScriptExecutionTime": "78.9753509933775"
+}, {
+  "canonicalDomain": "*.opinionstage.com",
+  "totalExecutionTime": "113005.30899999982",
+  "totalOccurrences": "150",
+  "totalScripts": "353",
+  "averageExecutionTime": "753.36872666666568",
+  "averageScriptExecutionTime": "265.26087977777757"
+}, {
+  "canonicalDomain": "*.queue-it.net",
+  "totalExecutionTime": "65552.919000000664",
+  "totalOccurrences": "149",
+  "totalScripts": "166",
+  "averageExecutionTime": "439.95247651007168",
+  "averageScriptExecutionTime": "399.52109563758859"
+}, {
+  "canonicalDomain": "dropahint.love",
+  "totalExecutionTime": "14337.462000000007",
+  "totalOccurrences": "148",
+  "totalScripts": "148",
+  "averageExecutionTime": "96.874743243243287",
+  "averageScriptExecutionTime": "96.874743243243287"
+}, {
+  "canonicalDomain": "*.canddi.com",
+  "totalExecutionTime": "87659.480999999942",
+  "totalOccurrences": "146",
+  "totalScripts": "189",
+  "averageExecutionTime": "600.4074041095887",
+  "averageScriptExecutionTime": "480.91530479452013"
+}, {
+  "canonicalDomain": "*.buysellads.com",
+  "totalExecutionTime": "122828.30599999972",
+  "totalOccurrences": "145",
+  "totalScripts": "155",
+  "averageExecutionTime": "847.09176551723942",
+  "averageScriptExecutionTime": "827.17021206896356"
+}, {
+  "canonicalDomain": "ceros.com",
+  "totalExecutionTime": "38857.354999999989",
+  "totalOccurrences": "142",
+  "totalScripts": "388",
+  "averageExecutionTime": "273.64334507042247",
+  "averageScriptExecutionTime": "94.411358148893314"
+}, {
+  "canonicalDomain": "*.storygize.net",
+  "totalExecutionTime": "47464.346999999558",
+  "totalOccurrences": "141",
+  "totalScripts": "186",
+  "averageExecutionTime": "336.62657446808197",
+  "averageScriptExecutionTime": "265.58514302600184"
+}, {
+  "canonicalDomain": "*.woosmap.com",
+  "totalExecutionTime": "49310.757000000136",
+  "totalOccurrences": "140",
+  "totalScripts": "157",
+  "averageExecutionTime": "352.21969285714363",
+  "averageScriptExecutionTime": "234.37257857142887"
+}, {
+  "canonicalDomain": "*.recollect.net",
+  "totalExecutionTime": "219459.92499999946",
+  "totalOccurrences": "136",
+  "totalScripts": "403",
+  "averageExecutionTime": "1613.6759191176434",
+  "averageScriptExecutionTime": "530.23101421568481"
+}, {
+  "canonicalDomain": "*.dropboxusercontent.com",
+  "totalExecutionTime": "101740.06399999991",
+  "totalOccurrences": "135",
+  "totalScripts": "161",
+  "averageExecutionTime": "753.6301037037033",
+  "averageScriptExecutionTime": "595.21641382715848"
+}, {
+  "canonicalDomain": "*.questionpro.com",
+  "totalExecutionTime": "26436.858999999986",
+  "totalOccurrences": "134",
+  "totalScripts": "196",
+  "averageExecutionTime": "197.28999253731334",
+  "averageScriptExecutionTime": "140.37720522388062"
+}, {
+  "canonicalDomain": "*.firstimpression.io",
+  "totalExecutionTime": "93347.608999999662",
+  "totalOccurrences": "134",
+  "totalScripts": "211",
+  "averageExecutionTime": "696.62394776119163",
+  "averageScriptExecutionTime": "366.64819092039716"
+}, {
+  "canonicalDomain": "*.reciteme.com",
+  "totalExecutionTime": "18553.604999999952",
+  "totalOccurrences": "133",
+  "totalScripts": "135",
+  "averageExecutionTime": "139.50078947368382",
+  "averageScriptExecutionTime": "138.36722556390936"
+}, {
+  "canonicalDomain": "*.proper.io",
+  "totalExecutionTime": "265364.96799999918",
+  "totalOccurrences": "133",
+  "totalScripts": "150",
+  "averageExecutionTime": "1995.2253233082631",
+  "averageScriptExecutionTime": "1839.240015037589"
+}, {
+  "canonicalDomain": "*.attributionapp.com",
+  "totalExecutionTime": "43723.025999999911",
+  "totalOccurrences": "131",
+  "totalScripts": "135",
+  "averageExecutionTime": "333.7635572519078",
+  "averageScriptExecutionTime": "325.42681679389261"
+}, {
+  "canonicalDomain": "*.drtvtracker.com",
+  "totalExecutionTime": "9730.1110000000044",
+  "totalOccurrences": "130",
+  "totalScripts": "130",
+  "averageExecutionTime": "74.847007692307727",
+  "averageScriptExecutionTime": "74.847007692307727"
+}, {
+  "canonicalDomain": "*.loginradius.com",
+  "totalExecutionTime": "14194.438999999986",
+  "totalOccurrences": "129",
+  "totalScripts": "154",
+  "averageExecutionTime": "110.03441085271311",
+  "averageScriptExecutionTime": "85.959552971576073"
+}, {
+  "canonicalDomain": "*.travel-assets.com",
+  "totalExecutionTime": "157332.43099999963",
+  "totalOccurrences": "129",
+  "totalScripts": "507",
+  "averageExecutionTime": "1219.6312480620122",
+  "averageScriptExecutionTime": "285.76982121939153"
+}, {
+  "canonicalDomain": "*.theadex.com",
+  "totalExecutionTime": "11088.322999999999",
+  "totalOccurrences": "128",
+  "totalScripts": "149",
+  "averageExecutionTime": "86.627523437500031",
+  "averageScriptExecutionTime": "77.407816406249978"
+}, {
+  "canonicalDomain": "*.force24.co.uk",
+  "totalExecutionTime": "12269.290999999994",
+  "totalOccurrences": "126",
+  "totalScripts": "126",
+  "averageExecutionTime": "97.3753253968254",
+  "averageScriptExecutionTime": "97.3753253968254"
+}, {
+  "canonicalDomain": "*.c3tag.com",
+  "totalExecutionTime": "40703.02199999999",
+  "totalOccurrences": "124",
+  "totalScripts": "136",
+  "averageExecutionTime": "328.25017741935471",
+  "averageScriptExecutionTime": "309.37083870967729"
+}, {
+  "canonicalDomain": "*.zmags.com",
+  "totalExecutionTime": "296513.85000000149",
+  "totalOccurrences": "124",
+  "totalScripts": "397",
+  "averageExecutionTime": "2391.2407258064627",
+  "averageScriptExecutionTime": "588.4825404629554"
+}, {
+  "canonicalDomain": "*.backinstock.org",
+  "totalExecutionTime": "3912.863",
+  "totalOccurrences": "123",
+  "totalScripts": "123",
+  "averageExecutionTime": "31.8118943089431",
+  "averageScriptExecutionTime": "31.8118943089431"
+}, {
+  "canonicalDomain": "*.linksynergy.com",
+  "totalExecutionTime": "15581.807999999988",
+  "totalOccurrences": "123",
+  "totalScripts": "146",
+  "averageExecutionTime": "126.68136585365838",
+  "averageScriptExecutionTime": "106.4351368563685"
+}, {
+  "canonicalDomain": "*.metaffiliation.com",
+  "totalExecutionTime": "17816.492",
+  "totalOccurrences": "122",
+  "totalScripts": "128",
+  "averageExecutionTime": "146.03681967213095",
+  "averageScriptExecutionTime": "138.8333360655736"
+}, {
+  "canonicalDomain": "*.contentabc.com",
+  "totalExecutionTime": "4128.8140000000012",
+  "totalOccurrences": "120",
+  "totalScripts": "151",
+  "averageExecutionTime": "34.406783333333337",
+  "averageScriptExecutionTime": "27.391226041666673"
+}, {
+  "canonicalDomain": "*.ably.io",
+  "totalExecutionTime": "13269.129999999996",
+  "totalOccurrences": "119",
+  "totalScripts": "119",
+  "averageExecutionTime": "111.50529411764705",
+  "averageScriptExecutionTime": "111.50529411764705"
+}, {
+  "canonicalDomain": "*.redintelligence.net",
+  "totalExecutionTime": "850.5160000000003",
+  "totalOccurrences": "118",
+  "totalScripts": "119",
+  "averageExecutionTime": "7.2077627118644045",
+  "averageScriptExecutionTime": "7.1795423728813548"
+}, {
+  "canonicalDomain": "*.edgecastcdn.net",
+  "totalExecutionTime": "89062.053999999567",
+  "totalOccurrences": "115",
+  "totalScripts": "173",
+  "averageExecutionTime": "774.45264347825719",
+  "averageScriptExecutionTime": "424.82172956521572"
+}, {
+  "canonicalDomain": "*.epoq.de",
+  "totalExecutionTime": "57187.471999999943",
+  "totalOccurrences": "114",
+  "totalScripts": "157",
+  "averageExecutionTime": "501.64449122806974",
+  "averageScriptExecutionTime": "360.21284502923919"
+}, {
+  "canonicalDomain": "*.pubnation.com",
+  "totalExecutionTime": "649549.79399999825",
+  "totalOccurrences": "113",
+  "totalScripts": "1222",
+  "averageExecutionTime": "5748.2282654867158",
+  "averageScriptExecutionTime": "504.78221311274655"
+}, {
+  "canonicalDomain": "*.btttag.com",
+  "totalExecutionTime": "49795.133000000533",
+  "totalOccurrences": "112",
+  "totalScripts": "112",
+  "averageExecutionTime": "444.599401785719",
+  "averageScriptExecutionTime": "444.599401785719"
+}, {
+  "canonicalDomain": "*.tubemogul.com",
+  "totalExecutionTime": "16998.842999999997",
+  "totalOccurrences": "107",
+  "totalScripts": "117",
+  "averageExecutionTime": "158.86769158878494",
+  "averageScriptExecutionTime": "150.58431931464173"
+}, {
+  "canonicalDomain": "*.adzerk.net",
+  "totalExecutionTime": "26037.784999999847",
+  "totalOccurrences": "105",
+  "totalScripts": "112",
+  "averageExecutionTime": "247.9789047619031",
+  "averageScriptExecutionTime": "234.73543809523659"
+}, {
+  "canonicalDomain": "*.neodatagroup.com",
+  "totalExecutionTime": "13168.117999999999",
+  "totalOccurrences": "102",
+  "totalScripts": "102",
+  "averageExecutionTime": "129.09919607843136",
+  "averageScriptExecutionTime": "129.09919607843136"
+}, {
+  "canonicalDomain": "*.segmint.net",
+  "totalExecutionTime": "12963.286999999997",
+  "totalOccurrences": "102",
+  "totalScripts": "103",
+  "averageExecutionTime": "127.09104901960775",
+  "averageScriptExecutionTime": "120.22510784313722"
+}, {
+  "canonicalDomain": "*.rtoaster.jp",
+  "totalExecutionTime": "15476.550999999972",
+  "totalOccurrences": "101",
+  "totalScripts": "106",
+  "averageExecutionTime": "153.23317821782155",
+  "averageScriptExecutionTime": "145.72539603960365"
+}, {
+  "canonicalDomain": "*.syteapi.com",
+  "totalExecutionTime": "86899.469999999914",
+  "totalOccurrences": "100",
+  "totalScripts": "498",
+  "averageExecutionTime": "868.99469999999917",
+  "averageScriptExecutionTime": "169.44418630771995"
+}, {
+  "canonicalDomain": "*.histats.com",
+  "totalExecutionTime": "5836.8590000000013",
+  "totalOccurrences": "99",
+  "totalScripts": "99",
+  "averageExecutionTime": "58.958171717171723",
+  "averageScriptExecutionTime": "58.958171717171723"
+}, {
+  "canonicalDomain": "*.dianomi.com",
+  "totalExecutionTime": "38827.84600000002",
+  "totalOccurrences": "98",
+  "totalScripts": "289",
+  "averageExecutionTime": "396.20251020408176",
+  "averageScriptExecutionTime": "156.44148334143188"
+}, {
+  "canonicalDomain": "*.qodeinteractive.com",
+  "totalExecutionTime": "1649702.7370000232",
+  "totalOccurrences": "98",
+  "totalScripts": "895",
+  "averageExecutionTime": "16833.701397959423",
+  "averageScriptExecutionTime": "1780.1738403279192"
+}, {
+  "canonicalDomain": "*.a8723.com",
+  "totalExecutionTime": "7809.9389999999939",
+  "totalOccurrences": "98",
+  "totalScripts": "98",
+  "averageExecutionTime": "79.693255102040766",
+  "averageScriptExecutionTime": "79.693255102040766"
+}, {
+  "canonicalDomain": "*.dynamicconverter.com",
+  "totalExecutionTime": "53582.45400000002",
+  "totalOccurrences": "97",
+  "totalScripts": "103",
+  "averageExecutionTime": "552.39643298969077",
+  "averageScriptExecutionTime": "530.749226804124"
+}, {
+  "canonicalDomain": "*.counciladvertising.net",
+  "totalExecutionTime": "21527.370999999981",
+  "totalOccurrences": "97",
+  "totalScripts": "167",
+  "averageExecutionTime": "221.93165979381439",
+  "averageScriptExecutionTime": "131.91831099656343"
+}, {
+  "canonicalDomain": "*.rightnowtech.com",
+  "totalExecutionTime": "7636.9069999999992",
+  "totalOccurrences": "97",
+  "totalScripts": "97",
+  "averageExecutionTime": "78.731000000000009",
+  "averageScriptExecutionTime": "78.731000000000009"
+}, {
+  "canonicalDomain": "*.atgsvcs.com",
+  "totalExecutionTime": "10790.099999999999",
+  "totalOccurrences": "97",
+  "totalScripts": "140",
+  "averageExecutionTime": "111.2381443298969",
+  "averageScriptExecutionTime": "79.124030927835037"
+}, {
+  "canonicalDomain": "*.tag4arm.com",
+  "totalExecutionTime": "6312.4070000000011",
+  "totalOccurrences": "96",
+  "totalScripts": "96",
+  "averageExecutionTime": "65.754239583333344",
+  "averageScriptExecutionTime": "65.754239583333344"
+}, {
+  "canonicalDomain": "*.exponential.com",
+  "totalExecutionTime": "3442.789",
+  "totalOccurrences": "95",
+  "totalScripts": "95",
+  "averageExecutionTime": "36.23988421052632",
+  "averageScriptExecutionTime": "36.23988421052632"
+}, {
+  "canonicalDomain": "*.ioam.de",
+  "totalExecutionTime": "10745.959999999963",
+  "totalOccurrences": "95",
+  "totalScripts": "95",
+  "averageExecutionTime": "113.11536842105227",
+  "averageScriptExecutionTime": "113.11536842105227"
+}, {
+  "canonicalDomain": "*.whoson.com",
+  "totalExecutionTime": "14915.738000000005",
+  "totalOccurrences": "95",
+  "totalScripts": "219",
+  "averageExecutionTime": "157.00776842105265",
+  "averageScriptExecutionTime": "68.627781578947364"
+}, {
+  "canonicalDomain": "*.wdfl.co",
+  "totalExecutionTime": "5059.0970000000025",
+  "totalOccurrences": "94",
+  "totalScripts": "94",
+  "averageExecutionTime": "53.820180851063824",
+  "averageScriptExecutionTime": "53.820180851063824"
+}, {
+  "canonicalDomain": "*.inq.com",
+  "totalExecutionTime": "15586.007999999982",
+  "totalOccurrences": "93",
+  "totalScripts": "130",
+  "averageExecutionTime": "167.59148387096749",
+  "averageScriptExecutionTime": "108.2936066308243"
+}, {
+  "canonicalDomain": "*.getambassador.com",
+  "totalExecutionTime": "30159.747999999945",
+  "totalOccurrences": "93",
+  "totalScripts": "107",
+  "averageExecutionTime": "324.29836559139733",
+  "averageScriptExecutionTime": "240.81998673835088"
+}, {
+  "canonicalDomain": "*.heatmap.it",
+  "totalExecutionTime": "4320.188000000001",
+  "totalOccurrences": "92",
+  "totalScripts": "93",
+  "averageExecutionTime": "46.958565217391332",
+  "averageScriptExecutionTime": "46.519527173913069"
+}, {
+  "canonicalDomain": "*.leadboxer.com",
+  "totalExecutionTime": "7573.8240000000033",
+  "totalOccurrences": "92",
+  "totalScripts": "94",
+  "averageExecutionTime": "82.3241739130435",
+  "averageScriptExecutionTime": "80.757624999999976"
+}, {
+  "canonicalDomain": "*.byside.com",
+  "totalExecutionTime": "54559.861999999906",
+  "totalOccurrences": "91",
+  "totalScripts": "179",
+  "averageExecutionTime": "599.55892307692227",
+  "averageScriptExecutionTime": "322.3467490842487"
+}, {
+  "canonicalDomain": "*.playbuzz.com",
+  "totalExecutionTime": "35035.18099999996",
+  "totalOccurrences": "91",
+  "totalScripts": "91",
+  "averageExecutionTime": "385.00198901098889",
+  "averageScriptExecutionTime": "385.00198901098889"
+}, {
+  "canonicalDomain": "*.hawksearch.com",
+  "totalExecutionTime": "10365.011",
+  "totalOccurrences": "91",
+  "totalScripts": "95",
+  "averageExecutionTime": "113.90121978021978",
+  "averageScriptExecutionTime": "110.4540164835165"
+}, {
+  "canonicalDomain": "*.bbb.org",
+  "totalExecutionTime": "9070.170000000031",
+  "totalOccurrences": "90",
+  "totalScripts": "92",
+  "averageExecutionTime": "100.77966666666705",
+  "averageScriptExecutionTime": "77.735155555555679"
+}, {
+  "canonicalDomain": "*.slpht.com",
+  "totalExecutionTime": "8709.783",
+  "totalOccurrences": "90",
+  "totalScripts": "90",
+  "averageExecutionTime": "96.77536666666667",
+  "averageScriptExecutionTime": "96.77536666666667"
+}, {
+  "canonicalDomain": "*.autopilothq.com",
+  "totalExecutionTime": "16926.240999999987",
+  "totalOccurrences": "90",
+  "totalScripts": "97",
+  "averageExecutionTime": "188.06934444444428",
+  "averageScriptExecutionTime": "180.0371055555554"
+}, {
+  "canonicalDomain": "*.swoop.com",
+  "totalExecutionTime": "12573.796999999997",
+  "totalOccurrences": "87",
+  "totalScripts": "101",
+  "averageExecutionTime": "144.5264022988506",
+  "averageScriptExecutionTime": "130.65157088122606"
+}, {
+  "canonicalDomain": "*.mention-me.com",
+  "totalExecutionTime": "26432.523999999979",
+  "totalOccurrences": "86",
+  "totalScripts": "178",
+  "averageExecutionTime": "307.35493023255793",
+  "averageScriptExecutionTime": "143.85610091823546"
+}, {
+  "canonicalDomain": "*.jivox.com",
+  "totalExecutionTime": "38444.213999999964",
+  "totalOccurrences": "86",
+  "totalScripts": "277",
+  "averageExecutionTime": "447.02574418604615",
+  "averageScriptExecutionTime": "132.92050329457348"
+}, {
+  "canonicalDomain": "*.dashhudson.com",
+  "totalExecutionTime": "190624.73800000013",
+  "totalOccurrences": "85",
+  "totalScripts": "85",
+  "averageExecutionTime": "2242.64397647059",
+  "averageScriptExecutionTime": "2242.64397647059"
+}, {
+  "canonicalDomain": "*.ontame.io",
+  "totalExecutionTime": "18036.3549999997",
+  "totalOccurrences": "85",
+  "totalScripts": "100",
+  "averageExecutionTime": "212.19241176470237",
+  "averageScriptExecutionTime": "192.22129411764371"
+}, {
+  "canonicalDomain": "*.adziff.com",
+  "totalExecutionTime": "24761.223999999973",
+  "totalOccurrences": "84",
+  "totalScripts": "84",
+  "averageExecutionTime": "294.77647619047576",
+  "averageScriptExecutionTime": "294.77647619047576"
+}, {
+  "canonicalDomain": "*.wpengine.com",
+  "totalExecutionTime": "52629.04999999993",
+  "totalOccurrences": "82",
+  "totalScripts": "141",
+  "averageExecutionTime": "641.81768292682875",
+  "averageScriptExecutionTime": "204.01586126113042"
+}, {
+  "canonicalDomain": "*.web-call-analytics.com",
+  "totalExecutionTime": "13906.275999999978",
+  "totalOccurrences": "80",
+  "totalScripts": "97",
+  "averageExecutionTime": "173.82844999999978",
+  "averageScriptExecutionTime": "152.13274374999966"
+}, {
+  "canonicalDomain": "*.flipboard.com",
+  "totalExecutionTime": "61372.141999999782",
+  "totalOccurrences": "80",
+  "totalScripts": "187",
+  "averageExecutionTime": "767.15177499999731",
+  "averageScriptExecutionTime": "203.40675791666587"
+}, {
+  "canonicalDomain": "*.dmca.com",
+  "totalExecutionTime": "8814.9159999999883",
+  "totalOccurrences": "80",
+  "totalScripts": "82",
+  "averageExecutionTime": "110.18644999999988",
+  "averageScriptExecutionTime": "104.28007499999987"
+}, {
+  "canonicalDomain": "*.hp.com",
+  "totalExecutionTime": "254467.81800000119",
+  "totalOccurrences": "78",
+  "totalScripts": "297",
+  "averageExecutionTime": "3262.407923076938",
+  "averageScriptExecutionTime": "846.35488934442037"
+}, {
+  "canonicalDomain": "*.pangolin.blue",
+  "totalExecutionTime": "29621.491999999926",
+  "totalOccurrences": "77",
+  "totalScripts": "127",
+  "averageExecutionTime": "384.69470129870052",
+  "averageScriptExecutionTime": "225.77987229437176"
+}, {
+  "canonicalDomain": "*.turn.com",
+  "totalExecutionTime": "4675.382",
+  "totalOccurrences": "75",
+  "totalScripts": "78",
+  "averageExecutionTime": "62.33842666666667",
+  "averageScriptExecutionTime": "59.949646666666659"
+}, {
+  "canonicalDomain": "*.analytics-egain.com",
+  "totalExecutionTime": "5916.6460000000006",
+  "totalOccurrences": "74",
+  "totalScripts": "75",
+  "averageExecutionTime": "79.954675675675674",
+  "averageScriptExecutionTime": "79.309614864864869"
+}, {
+  "canonicalDomain": "*.servebom.com",
+  "totalExecutionTime": "41.136999999999979",
+  "totalOccurrences": "74",
+  "totalScripts": "164",
+  "averageExecutionTime": "0.55590540540540523",
+  "averageScriptExecutionTime": "0.22938288288288283"
+}, {
+  "canonicalDomain": "*.wowanalytics.co.uk",
+  "totalExecutionTime": "23147.36399999947",
+  "totalOccurrences": "73",
+  "totalScripts": "84",
+  "averageExecutionTime": "317.08717808218466",
+  "averageScriptExecutionTime": "283.27808904108889"
+}, {
+  "canonicalDomain": "*.netmng.com",
+  "totalExecutionTime": "5098.4230000000025",
+  "totalOccurrences": "73",
+  "totalScripts": "80",
+  "averageExecutionTime": "69.841410958904163",
+  "averageScriptExecutionTime": "64.042623287671248"
+}, {
+  "canonicalDomain": "*.prezi.com",
+  "totalExecutionTime": "95865.405999999843",
+  "totalOccurrences": "72",
+  "totalScripts": "293",
+  "averageExecutionTime": "1331.4639722222196",
+  "averageScriptExecutionTime": "313.10865358796224"
+}, {
+  "canonicalDomain": "*.tribl.io",
+  "totalExecutionTime": "7976.50799999998",
+  "totalOccurrences": "71",
+  "totalScripts": "84",
+  "averageExecutionTime": "112.34518309859126",
+  "averageScriptExecutionTime": "92.8095211267603"
+}, {
+  "canonicalDomain": "*.psplugin.com",
+  "totalExecutionTime": "47848.669999999882",
+  "totalOccurrences": "71",
+  "totalScripts": "71",
+  "averageExecutionTime": "673.92492957746322",
+  "averageScriptExecutionTime": "673.92492957746322"
+}, {
+  "canonicalDomain": "*.net.pl",
+  "totalExecutionTime": "28632.969999999943",
+  "totalOccurrences": "71",
+  "totalScripts": "119",
+  "averageExecutionTime": "403.28126760563305",
+  "averageScriptExecutionTime": "184.57180751173681"
+}, {
+  "canonicalDomain": "*.iteratehq.com",
+  "totalExecutionTime": "5114.0939999999973",
+  "totalOccurrences": "71",
+  "totalScripts": "73",
+  "averageExecutionTime": "72.029492957746442",
+  "averageScriptExecutionTime": "66.906140845070411"
+}, {
+  "canonicalDomain": "*.easypolls.net",
+  "totalExecutionTime": "24249.937999999845",
+  "totalOccurrences": "71",
+  "totalScripts": "119",
+  "averageExecutionTime": "341.54842253520934",
+  "averageScriptExecutionTime": "161.34986586183686"
+}, {
+  "canonicalDomain": "*.digicert.com",
+  "totalExecutionTime": "13892.383999999958",
+  "totalOccurrences": "71",
+  "totalScripts": "91",
+  "averageExecutionTime": "195.66738028168967",
+  "averageScriptExecutionTime": "96.765766040688391"
+}, {
+  "canonicalDomain": "*.audioboom.com",
+  "totalExecutionTime": "102877.05099999977",
+  "totalOccurrences": "70",
+  "totalScripts": "514",
+  "averageExecutionTime": "1469.672157142855",
+  "averageScriptExecutionTime": "170.39123211184034"
+}, {
+  "canonicalDomain": "*.uicdn.com",
+  "totalExecutionTime": "11915.371",
+  "totalOccurrences": "70",
+  "totalScripts": "144",
+  "averageExecutionTime": "170.21958571428576",
+  "averageScriptExecutionTime": "76.49162049319726"
+}, {
+  "canonicalDomain": "*.3.com",
+  "totalExecutionTime": "73099.33999999988",
+  "totalOccurrences": "70",
+  "totalScripts": "183",
+  "averageExecutionTime": "1044.2762857142841",
+  "averageScriptExecutionTime": "382.27251187074768"
+}, {
+  "canonicalDomain": "*.adlooxtracking.com",
+  "totalExecutionTime": "44283.46100000001",
+  "totalOccurrences": "67",
+  "totalScripts": "76",
+  "averageExecutionTime": "660.94717910447764",
+  "averageScriptExecutionTime": "587.7940671641793"
+}, {
+  "canonicalDomain": "*.withcabin.com",
+  "totalExecutionTime": "2552.4190000000008",
+  "totalOccurrences": "66",
+  "totalScripts": "66",
+  "averageExecutionTime": "38.673015151515145",
+  "averageScriptExecutionTime": "38.673015151515145"
+}, {
+  "canonicalDomain": "*.prefixbox.com",
+  "totalExecutionTime": "59769.150999999874",
+  "totalOccurrences": "65",
+  "totalScripts": "183",
+  "averageExecutionTime": "919.52539999999817",
+  "averageScriptExecutionTime": "333.71567820512763"
+}, {
+  "canonicalDomain": "*.extreme-dm.com",
+  "totalExecutionTime": "4593.011000000015",
+  "totalOccurrences": "65",
+  "totalScripts": "65",
+  "averageExecutionTime": "70.661707692307871",
+  "averageScriptExecutionTime": "70.661707692307871"
+}, {
+  "canonicalDomain": "*.bannerflow.com",
+  "totalExecutionTime": "63737.080000000264",
+  "totalOccurrences": "64",
+  "totalScripts": "274",
+  "averageExecutionTime": "995.89187500000412",
+  "averageScriptExecutionTime": "232.0092641081585"
+}, {
+  "canonicalDomain": "*.fwmrm.net",
+  "totalExecutionTime": "9756.7770000000055",
+  "totalOccurrences": "64",
+  "totalScripts": "65",
+  "averageExecutionTime": "152.44964062500006",
+  "averageScriptExecutionTime": "151.64828906250008"
+}, {
+  "canonicalDomain": "*.tapad.com",
+  "totalExecutionTime": "11.183999999999994",
+  "totalOccurrences": "63",
+  "totalScripts": "63",
+  "averageExecutionTime": "0.17752380952380939",
+  "averageScriptExecutionTime": "0.17752380952380939"
+}, {
+  "canonicalDomain": "*.h-cdn.com",
+  "totalExecutionTime": "77190.007999999856",
+  "totalOccurrences": "62",
+  "totalScripts": "99",
+  "averageExecutionTime": "1245.0001290322559",
+  "averageScriptExecutionTime": "844.15813978494486"
+}, {
+  "canonicalDomain": "*.qubit.com",
+  "totalExecutionTime": "77902.905999999755",
+  "totalOccurrences": "62",
+  "totalScripts": "62",
+  "averageExecutionTime": "1256.4984838709638",
+  "averageScriptExecutionTime": "1256.4984838709638"
+}, {
+  "canonicalDomain": "*.mtvnservices.com",
+  "totalExecutionTime": "26080.122999999952",
+  "totalOccurrences": "61",
+  "totalScripts": "84",
+  "averageExecutionTime": "427.54299999999915",
+  "averageScriptExecutionTime": "324.13492896174836"
+}, {
+  "canonicalDomain": "*.custhelp.com",
+  "totalExecutionTime": "79109.659000000131",
+  "totalOccurrences": "61",
+  "totalScripts": "164",
+  "averageExecutionTime": "1296.8796557377066",
+  "averageScriptExecutionTime": "303.61800853499926"
+}, {
+  "canonicalDomain": "*.leafletjs.com",
+  "totalExecutionTime": "3447.8479999999995",
+  "totalOccurrences": "61",
+  "totalScripts": "62",
+  "averageExecutionTime": "56.52209836065574",
+  "averageScriptExecutionTime": "55.69134426229509"
+}, {
+  "canonicalDomain": "*.mplxtms.com",
+  "totalExecutionTime": "17261.607000000007",
+  "totalOccurrences": "60",
+  "totalScripts": "60",
+  "averageExecutionTime": "287.69345000000004",
+  "averageScriptExecutionTime": "287.69345000000004"
+}, {
+  "canonicalDomain": "*.ipredictive.com",
+  "totalExecutionTime": "4912.0469999999905",
+  "totalOccurrences": "60",
+  "totalScripts": "60",
+  "averageExecutionTime": "81.867449999999835",
+  "averageScriptExecutionTime": "81.867449999999835"
+}, {
+  "canonicalDomain": "*.smct.co",
+  "totalExecutionTime": "4509.0879999999961",
+  "totalOccurrences": "59",
+  "totalScripts": "60",
+  "averageExecutionTime": "76.425220338982982",
+  "averageScriptExecutionTime": "75.447847457627049"
+}, {
+  "canonicalDomain": "*.actblue.com",
+  "totalExecutionTime": "33312.621999999908",
+  "totalOccurrences": "59",
+  "totalScripts": "100",
+  "averageExecutionTime": "564.62071186440528",
+  "averageScriptExecutionTime": "319.48222951977311"
+}, {
+  "canonicalDomain": "*.gettyimages.com",
+  "totalExecutionTime": "11732.056999999928",
+  "totalOccurrences": "59",
+  "totalScripts": "167",
+  "averageExecutionTime": "198.84842372881241",
+  "averageScriptExecutionTime": "58.2244403055981"
+}, {
+  "canonicalDomain": "*.episerver.net",
+  "totalExecutionTime": "7017.6370000000024",
+  "totalOccurrences": "59",
+  "totalScripts": "59",
+  "averageExecutionTime": "118.94300000000003",
+  "averageScriptExecutionTime": "118.94300000000003"
+}, {
+  "canonicalDomain": "*.taggstar.com",
+  "totalExecutionTime": "15969.285999999996",
+  "totalOccurrences": "59",
+  "totalScripts": "131",
+  "averageExecutionTime": "270.66586440677969",
+  "averageScriptExecutionTime": "117.28820903954801"
+}, {
+  "canonicalDomain": "*.ui-portal.de",
+  "totalExecutionTime": "15097.521999999988",
+  "totalOccurrences": "56",
+  "totalScripts": "108",
+  "averageExecutionTime": "269.59860714285679",
+  "averageScriptExecutionTime": "141.7395014880951"
+}, {
+  "canonicalDomain": "*.perimeterx.net",
+  "totalExecutionTime": "98064.149999999456",
+  "totalOccurrences": "55",
+  "totalScripts": "59",
+  "averageExecutionTime": "1782.9845454545352",
+  "averageScriptExecutionTime": "1647.1094909090816"
+}, {
+  "canonicalDomain": "*.ipinfo.io",
+  "totalExecutionTime": "4692.0019999999977",
+  "totalOccurrences": "55",
+  "totalScripts": "55",
+  "averageExecutionTime": "85.309127272727267",
+  "averageScriptExecutionTime": "85.309127272727267"
+}, {
+  "canonicalDomain": "*.imallcdn.net",
+  "totalExecutionTime": "54699.813999999831",
+  "totalOccurrences": "55",
+  "totalScripts": "167",
+  "averageExecutionTime": "994.54207272726978",
+  "averageScriptExecutionTime": "394.80801106060477"
+}, {
+  "canonicalDomain": "*.kissmetrics.com",
+  "totalExecutionTime": "4403.2849999999962",
+  "totalOccurrences": "54",
+  "totalScripts": "54",
+  "averageExecutionTime": "81.542314814814773",
+  "averageScriptExecutionTime": "81.542314814814773"
+}, {
+  "canonicalDomain": "*.pulseinsights.com",
+  "totalExecutionTime": "6265.8820000000005",
+  "totalOccurrences": "54",
+  "totalScripts": "69",
+  "averageExecutionTime": "116.0348518518519",
+  "averageScriptExecutionTime": "78.7337314814815"
+}, {
+  "canonicalDomain": "*.mediav.com",
+  "totalExecutionTime": "3489.4019999999996",
+  "totalOccurrences": "54",
+  "totalScripts": "64",
+  "averageExecutionTime": "64.618555555555531",
+  "averageScriptExecutionTime": "54.493601851851821"
+}, {
+  "canonicalDomain": "*.m2.ai",
+  "totalExecutionTime": "16832.496999999959",
+  "totalOccurrences": "54",
+  "totalScripts": "56",
+  "averageExecutionTime": "311.71290740740665",
+  "averageScriptExecutionTime": "283.18090740740672"
+}, {
+  "canonicalDomain": "*.lockerdome.com",
+  "totalExecutionTime": "6060.4850000000024",
+  "totalOccurrences": "53",
+  "totalScripts": "73",
+  "averageExecutionTime": "114.3487735849057",
+  "averageScriptExecutionTime": "81.0641588050315"
+}, {
+  "canonicalDomain": "*.usehero.com",
+  "totalExecutionTime": "19214.449999999844",
+  "totalOccurrences": "53",
+  "totalScripts": "66",
+  "averageExecutionTime": "362.53679245282723",
+  "averageScriptExecutionTime": "190.13998427672857"
+}, {
+  "canonicalDomain": "*.multiview.com",
+  "totalExecutionTime": "11345.339000000011",
+  "totalOccurrences": "53",
+  "totalScripts": "62",
+  "averageExecutionTime": "214.06300000000033",
+  "averageScriptExecutionTime": "159.41139937106914"
+}, {
+  "canonicalDomain": "*.mkt912.com",
+  "totalExecutionTime": "3593.2019999999993",
+  "totalOccurrences": "53",
+  "totalScripts": "53",
+  "averageExecutionTime": "67.796264150943358",
+  "averageScriptExecutionTime": "67.796264150943358"
+}, {
+  "canonicalDomain": "*.fresh8.co",
+  "totalExecutionTime": "327729.18200000044",
+  "totalOccurrences": "53",
+  "totalScripts": "409",
+  "averageExecutionTime": "6183.5694716981252",
+  "averageScriptExecutionTime": "831.82210570928135"
+}, {
+  "canonicalDomain": "*.bizrate.com",
+  "totalExecutionTime": "9705.7120000000014",
+  "totalOccurrences": "52",
+  "totalScripts": "77",
+  "averageExecutionTime": "186.6483076923077",
+  "averageScriptExecutionTime": "121.44075641025636"
+}, {
+  "canonicalDomain": "*.affiliatly.com",
+  "totalExecutionTime": "17840.603",
+  "totalOccurrences": "52",
+  "totalScripts": "55",
+  "averageExecutionTime": "343.08851923076907",
+  "averageScriptExecutionTime": "334.37158333333338"
+}, {
+  "canonicalDomain": "*.thinglink.com",
+  "totalExecutionTime": "1456.9880000000007",
+  "totalOccurrences": "51",
+  "totalScripts": "54",
+  "averageExecutionTime": "28.568392156862746",
+  "averageScriptExecutionTime": "26.033745098039219"
+}, {
+  "canonicalDomain": "*.conductrics.com",
+  "totalExecutionTime": "7752.6549999999725",
+  "totalOccurrences": "51",
+  "totalScripts": "51",
+  "averageExecutionTime": "152.01284313725435",
+  "averageScriptExecutionTime": "152.01284313725435"
+}, {
+  "canonicalDomain": "*.lenmit.com",
+  "totalExecutionTime": "3079.883",
+  "totalOccurrences": "49",
+  "totalScripts": "49",
+  "averageExecutionTime": "62.854755102040812",
+  "averageScriptExecutionTime": "62.854755102040812"
+}, {
+  "canonicalDomain": "*.reactful.com",
+  "totalExecutionTime": "12229.851999999986",
+  "totalOccurrences": "49",
+  "totalScripts": "49",
+  "averageExecutionTime": "249.58881632653029",
+  "averageScriptExecutionTime": "249.58881632653029"
+}, {
+  "canonicalDomain": "*.imgix.net",
+  "totalExecutionTime": "34923.833999999908",
+  "totalOccurrences": "49",
+  "totalScripts": "122",
+  "averageExecutionTime": "712.731306122447",
+  "averageScriptExecutionTime": "207.74456122448936"
+}, {
+  "canonicalDomain": "*.infusionsoft.com",
+  "totalExecutionTime": "29255.713999999993",
+  "totalOccurrences": "48",
+  "totalScripts": "56",
+  "averageExecutionTime": "609.49404166666625",
+  "averageScriptExecutionTime": "557.75556249999977"
+}, {
+  "canonicalDomain": "*.tm-awx.com",
+  "totalExecutionTime": "66620.535999999949",
+  "totalOccurrences": "48",
+  "totalScripts": "96",
+  "averageExecutionTime": "1387.9278333333323",
+  "averageScriptExecutionTime": "693.96391666666614"
+}, {
+  "canonicalDomain": "*.answerdash.com",
+  "totalExecutionTime": "16271.562999999975",
+  "totalOccurrences": "48",
+  "totalScripts": "96",
+  "averageExecutionTime": "338.99089583333279",
+  "averageScriptExecutionTime": "169.72369791666642"
+}, {
+  "canonicalDomain": "*.clickfuse.com",
+  "totalExecutionTime": "9617.65899999999",
+  "totalOccurrences": "47",
+  "totalScripts": "51",
+  "averageExecutionTime": "204.63104255319126",
+  "averageScriptExecutionTime": "192.04507801418416"
+}, {
+  "canonicalDomain": "*.mousestats.com",
+  "totalExecutionTime": "5299.7559999999539",
+  "totalOccurrences": "47",
+  "totalScripts": "48",
+  "averageExecutionTime": "112.7607659574458",
+  "averageScriptExecutionTime": "102.98053191489267"
+}, {
+  "canonicalDomain": "*.insipio.com",
+  "totalExecutionTime": "3071.9570000000003",
+  "totalOccurrences": "47",
+  "totalScripts": "47",
+  "averageExecutionTime": "65.360787234042533",
+  "averageScriptExecutionTime": "65.360787234042533"
+}, {
+  "canonicalDomain": "*.barnebys.com",
+  "totalExecutionTime": "75978.951000000117",
+  "totalOccurrences": "47",
+  "totalScripts": "102",
+  "averageExecutionTime": "1616.573425531918",
+  "averageScriptExecutionTime": "328.92486560283714"
+}, {
+  "canonicalDomain": "*.vergic.com",
+  "totalExecutionTime": "28855.061999999922",
+  "totalOccurrences": "46",
+  "totalScripts": "46",
+  "averageExecutionTime": "627.28395652173742",
+  "averageScriptExecutionTime": "627.28395652173742"
+}, {
+  "canonicalDomain": "*.atlasrtx.com",
+  "totalExecutionTime": "58312.809999999932",
+  "totalOccurrences": "46",
+  "totalScripts": "136",
+  "averageExecutionTime": "1267.6697826086943",
+  "averageScriptExecutionTime": "467.40650543478245"
+}, {
+  "canonicalDomain": "*.vivocha.com",
+  "totalExecutionTime": "42773.945999999931",
+  "totalOccurrences": "46",
+  "totalScripts": "108",
+  "averageExecutionTime": "929.86839130434635",
+  "averageScriptExecutionTime": "401.03489420289776"
+}, {
+  "canonicalDomain": "*.dialogtech.com",
+  "totalExecutionTime": "4258.9880000000012",
+  "totalOccurrences": "46",
+  "totalScripts": "56",
+  "averageExecutionTime": "92.58669565217393",
+  "averageScriptExecutionTime": "74.880054347826089"
+}, {
+  "canonicalDomain": "*.ztat.net",
+  "totalExecutionTime": "135266.9249999992",
+  "totalOccurrences": "45",
+  "totalScripts": "175",
+  "averageExecutionTime": "3005.9316666666496",
+  "averageScriptExecutionTime": "733.90462002644972"
+}, {
+  "canonicalDomain": "*.tagboard.com",
+  "totalExecutionTime": "50058.668999998888",
+  "totalOccurrences": "44",
+  "totalScripts": "152",
+  "averageExecutionTime": "1137.6970227272475",
+  "averageScriptExecutionTime": "295.94337840908554"
+}, {
+  "canonicalDomain": "*.elitechnology.com",
+  "totalExecutionTime": "31630.041999999939",
+  "totalOccurrences": "44",
+  "totalScripts": "44",
+  "averageExecutionTime": "718.86459090908954",
+  "averageScriptExecutionTime": "718.86459090908954"
+}, {
+  "canonicalDomain": "*.meltwaternews.com",
+  "totalExecutionTime": "20355.055000000015",
+  "totalOccurrences": "44",
+  "totalScripts": "50",
+  "averageExecutionTime": "462.61488636363669",
+  "averageScriptExecutionTime": "451.33732954545485"
+}, {
+  "canonicalDomain": "*.getcatch.com",
+  "totalExecutionTime": "16378.652000000006",
+  "totalOccurrences": "44",
+  "totalScripts": "47",
+  "averageExecutionTime": "372.24209090909096",
+  "averageScriptExecutionTime": "303.70918181818161"
+}, {
+  "canonicalDomain": "*.tifbs.net",
+  "totalExecutionTime": "1174.5040000000004",
+  "totalOccurrences": "43",
+  "totalScripts": "53",
+  "averageExecutionTime": "27.314046511627907",
+  "averageScriptExecutionTime": "21.967965116279071"
+}, {
+  "canonicalDomain": "*.miaozhen.com",
+  "totalExecutionTime": "4216.2080000000005",
+  "totalOccurrences": "43",
+  "totalScripts": "43",
+  "averageExecutionTime": "98.051348837209289",
+  "averageScriptExecutionTime": "98.051348837209289"
+}, {
+  "canonicalDomain": "*.stumble-upon.com",
+  "totalExecutionTime": "94948.302999999883",
+  "totalOccurrences": "41",
+  "totalScripts": "405",
+  "averageExecutionTime": "2315.8122682926805",
+  "averageScriptExecutionTime": "196.72661302163726"
+}, {
+  "canonicalDomain": "*.vextras.com",
+  "totalExecutionTime": "4680.9790000000012",
+  "totalOccurrences": "41",
+  "totalScripts": "41",
+  "averageExecutionTime": "114.17021951219516",
+  "averageScriptExecutionTime": "114.17021951219516"
+}, {
+  "canonicalDomain": "*.covet.pics",
+  "totalExecutionTime": "3752.4599999999996",
+  "totalOccurrences": "41",
+  "totalScripts": "43",
+  "averageExecutionTime": "91.523414634146349",
+  "averageScriptExecutionTime": "80.0174756097561"
+}, {
+  "canonicalDomain": "*.agilone.com",
+  "totalExecutionTime": "2724.8350000000009",
+  "totalOccurrences": "41",
+  "totalScripts": "42",
+  "averageExecutionTime": "66.45939024390249",
+  "averageScriptExecutionTime": "65.354902439024428"
+}, {
+  "canonicalDomain": "*.news.com.au",
+  "totalExecutionTime": "54515.100999999944",
+  "totalOccurrences": "40",
+  "totalScripts": "194",
+  "averageExecutionTime": "1362.8775249999985",
+  "averageScriptExecutionTime": "291.83959612012961"
+}, {
+  "canonicalDomain": "*.tiledesk.com",
+  "totalExecutionTime": "102273.3709999993",
+  "totalOccurrences": "40",
+  "totalScripts": "126",
+  "averageExecutionTime": "2556.8342749999829",
+  "averageScriptExecutionTime": "842.73205624999434"
+}, {
+  "canonicalDomain": "*.streamamg.com",
+  "totalExecutionTime": "25901.5069999997",
+  "totalOccurrences": "39",
+  "totalScripts": "57",
+  "averageExecutionTime": "664.1412051281975",
+  "averageScriptExecutionTime": "394.93089743589189"
+}, {
+  "canonicalDomain": "*.gomoxie.solutions",
+  "totalExecutionTime": "26551.951999999896",
+  "totalOccurrences": "38",
+  "totalScripts": "75",
+  "averageExecutionTime": "698.73557894736552",
+  "averageScriptExecutionTime": "353.03646052631444"
+}, {
+  "canonicalDomain": "*.starfieldtech.com",
+  "totalExecutionTime": "13303.798999999979",
+  "totalOccurrences": "38",
+  "totalScripts": "39",
+  "averageExecutionTime": "350.09997368421006",
+  "averageScriptExecutionTime": "342.99685526315727"
+}, {
+  "canonicalDomain": "*.cint.com",
+  "totalExecutionTime": "82168.465999999622",
+  "totalOccurrences": "37",
+  "totalScripts": "246",
+  "averageExecutionTime": "2220.7693513513409",
+  "averageScriptExecutionTime": "286.01656718439085"
+}, {
+  "canonicalDomain": "*.awempire.com",
+  "totalExecutionTime": "2781.3610000000008",
+  "totalOccurrences": "37",
+  "totalScripts": "59",
+  "averageExecutionTime": "75.171918918918948",
+  "averageScriptExecutionTime": "42.418117117117148"
+}, {
+  "canonicalDomain": "*.omguk.com",
+  "totalExecutionTime": "7993.927",
+  "totalOccurrences": "37",
+  "totalScripts": "38",
+  "averageExecutionTime": "216.05208108108107",
+  "averageScriptExecutionTime": "213.92620270270268"
+}, {
+  "canonicalDomain": "*.evbuc.com",
+  "totalExecutionTime": "3674.275999999998",
+  "totalOccurrences": "37",
+  "totalScripts": "57",
+  "averageExecutionTime": "99.304756756756731",
+  "averageScriptExecutionTime": "73.729605855855809"
+}, {
+  "canonicalDomain": "*.trust-guard.com",
+  "totalExecutionTime": "3817.1970000000006",
+  "totalOccurrences": "36",
+  "totalScripts": "48",
+  "averageExecutionTime": "106.03325000000001",
+  "averageScriptExecutionTime": "80.882388888888926"
+}, {
+  "canonicalDomain": "*.techtarget.com",
+  "totalExecutionTime": "2591.1319999999996",
+  "totalOccurrences": "36",
+  "totalScripts": "38",
+  "averageExecutionTime": "71.975888888888875",
+  "averageScriptExecutionTime": "65.736930555555546"
+}, {
+  "canonicalDomain": "*.sagepay.com",
+  "totalExecutionTime": "3971.9139999999961",
+  "totalOccurrences": "36",
+  "totalScripts": "36",
+  "averageExecutionTime": "110.33094444444437",
+  "averageScriptExecutionTime": "110.33094444444437"
+}, {
+  "canonicalDomain": "*.tradelab.fr",
+  "totalExecutionTime": "3297.4740000000015",
+  "totalOccurrences": "36",
+  "totalScripts": "42",
+  "averageExecutionTime": "91.596500000000077",
+  "averageScriptExecutionTime": "79.978027777777825"
+}, {
+  "canonicalDomain": "*.asapp.com",
+  "totalExecutionTime": "42081.993999999861",
+  "totalOccurrences": "35",
+  "totalScripts": "168",
+  "averageExecutionTime": "1202.342685714282",
+  "averageScriptExecutionTime": "234.30635523809451"
+}, {
+  "canonicalDomain": "*.brcdn.com",
+  "totalExecutionTime": "1996.215",
+  "totalOccurrences": "35",
+  "totalScripts": "35",
+  "averageExecutionTime": "57.03471428571428",
+  "averageScriptExecutionTime": "57.03471428571428"
+}, {
+  "canonicalDomain": "*.oneall.com",
+  "totalExecutionTime": "4859.0179999999973",
+  "totalOccurrences": "35",
+  "totalScripts": "38",
+  "averageExecutionTime": "138.82908571428567",
+  "averageScriptExecutionTime": "126.80262857142853"
+}, {
+  "canonicalDomain": "*.instansive.com",
+  "totalExecutionTime": "4410.8849999999993",
+  "totalOccurrences": "34",
+  "totalScripts": "34",
+  "averageExecutionTime": "129.7319117647059",
+  "averageScriptExecutionTime": "129.7319117647059"
+}, {
+  "canonicalDomain": "*.res-x.com",
+  "totalExecutionTime": "7319.9669999999915",
+  "totalOccurrences": "34",
+  "totalScripts": "34",
+  "averageExecutionTime": "215.29314705882328",
+  "averageScriptExecutionTime": "215.29314705882328"
+}, {
+  "canonicalDomain": "*.shoprunner.com",
+  "totalExecutionTime": "42326.234999999884",
+  "totalOccurrences": "34",
+  "totalScripts": "120",
+  "averageExecutionTime": "1244.889264705879",
+  "averageScriptExecutionTime": "316.18585539215576"
+}, {
+  "canonicalDomain": "*.aaxads.com",
+  "totalExecutionTime": "2156.1450000000004",
+  "totalOccurrences": "34",
+  "totalScripts": "34",
+  "averageExecutionTime": "63.416029411764711",
+  "averageScriptExecutionTime": "63.416029411764711"
+}, {
+  "canonicalDomain": "*.vee24.com",
+  "totalExecutionTime": "13702.943000000003",
+  "totalOccurrences": "33",
+  "totalScripts": "94",
+  "averageExecutionTime": "415.24069696969707",
+  "averageScriptExecutionTime": "143.54458080808084"
+}, {
+  "canonicalDomain": "*.trustev.com",
+  "totalExecutionTime": "6307.9959999999992",
+  "totalOccurrences": "33",
+  "totalScripts": "33",
+  "averageExecutionTime": "191.15139393939396",
+  "averageScriptExecutionTime": "191.15139393939396"
+}, {
+  "canonicalDomain": "*.imgur.com",
+  "totalExecutionTime": "19396.230000000298",
+  "totalOccurrences": "33",
+  "totalScripts": "123",
+  "averageExecutionTime": "587.76454545455442",
+  "averageScriptExecutionTime": "171.63300574795869"
+}, {
+  "canonicalDomain": "d1m54pdnjzjnhe.cloudfront.net",
+  "totalExecutionTime": "13128.999999999925",
+  "totalOccurrences": "32",
+  "totalScripts": "35",
+  "averageExecutionTime": "410.28124999999778",
+  "averageScriptExecutionTime": "341.72726562499815"
+}, {
+  "canonicalDomain": "*.adobetag.com",
+  "totalExecutionTime": "3547.0099999999993",
+  "totalOccurrences": "31",
+  "totalScripts": "37",
+  "averageExecutionTime": "114.4196774193548",
+  "averageScriptExecutionTime": "96.9920161290322"
+}, {
+  "canonicalDomain": "*.youplay.se",
+  "totalExecutionTime": "30764.642999999975",
+  "totalOccurrences": "31",
+  "totalScripts": "61",
+  "averageExecutionTime": "992.40783870967675",
+  "averageScriptExecutionTime": "503.2161182795694"
+}, {
+  "canonicalDomain": "*.cj.com",
+  "totalExecutionTime": "1928.33",
+  "totalOccurrences": "31",
+  "totalScripts": "31",
+  "averageExecutionTime": "62.204193548387082",
+  "averageScriptExecutionTime": "62.204193548387082"
+}, {
+  "canonicalDomain": "*.selectmedia.asia",
+  "totalExecutionTime": "61674.160999999884",
+  "totalOccurrences": "31",
+  "totalScripts": "89",
+  "averageExecutionTime": "1989.4890645161252",
+  "averageScriptExecutionTime": "721.837102534561"
+}, {
+  "canonicalDomain": "*.gnatta.com",
+  "totalExecutionTime": "4833.8229999999985",
+  "totalOccurrences": "31",
+  "totalScripts": "44",
+  "averageExecutionTime": "155.92977419354833",
+  "averageScriptExecutionTime": "106.07051612903224"
+}, {
+  "canonicalDomain": "*.richrelevance.com",
+  "totalExecutionTime": "43539.321000000666",
+  "totalOccurrences": "31",
+  "totalScripts": "34",
+  "averageExecutionTime": "1404.4942258064739",
+  "averageScriptExecutionTime": "1073.9978870967859"
+}, {
+  "canonicalDomain": "*.demandjump.com",
+  "totalExecutionTime": "5401.0469999999605",
+  "totalOccurrences": "30",
+  "totalScripts": "30",
+  "averageExecutionTime": "180.0348999999986",
+  "averageScriptExecutionTime": "180.0348999999986"
+}, {
+  "canonicalDomain": "*.sub2tech.com",
+  "totalExecutionTime": "5037.2479999999905",
+  "totalOccurrences": "30",
+  "totalScripts": "58",
+  "averageExecutionTime": "167.90826666666635",
+  "averageScriptExecutionTime": "84.723888888888723"
+}, {
+  "canonicalDomain": "*.emailcenteruk.com",
+  "totalExecutionTime": "4997.9629999999488",
+  "totalOccurrences": "30",
+  "totalScripts": "34",
+  "averageExecutionTime": "166.59876666666497",
+  "averageScriptExecutionTime": "148.09294999999824"
+}, {
+  "canonicalDomain": "*.mynewsdesk.com",
+  "totalExecutionTime": "379.85899999999992",
+  "totalOccurrences": "30",
+  "totalScripts": "31",
+  "averageExecutionTime": "12.661966666666663",
+  "averageScriptExecutionTime": "11.661549999999995"
+}, {
+  "canonicalDomain": "*.admanmedia.com",
+  "totalExecutionTime": "1609.6629999999993",
+  "totalOccurrences": "30",
+  "totalScripts": "36",
+  "averageExecutionTime": "53.65543333333332",
+  "averageScriptExecutionTime": "31.548299999999998"
+}, {
+  "canonicalDomain": "*.yummly.com",
+  "totalExecutionTime": "42124.583000000035",
+  "totalOccurrences": "30",
+  "totalScripts": "66",
+  "averageExecutionTime": "1404.152766666668",
+  "averageScriptExecutionTime": "581.13824444444447"
+}, {
+  "canonicalDomain": "*.webvideocore.net",
+  "totalExecutionTime": "46493.091999999524",
+  "totalOccurrences": "29",
+  "totalScripts": "110",
+  "averageExecutionTime": "1603.2100689655013",
+  "averageScriptExecutionTime": "433.42133505746693"
+}, {
+  "canonicalDomain": "*.integrate.com",
+  "totalExecutionTime": "9210.0009999999766",
+  "totalOccurrences": "28",
+  "totalScripts": "29",
+  "averageExecutionTime": "328.92860714285638",
+  "averageScriptExecutionTime": "321.98266071428492"
+}, {
+  "canonicalDomain": "*.vidpulse.com",
+  "totalExecutionTime": "13951.638999999992",
+  "totalOccurrences": "28",
+  "totalScripts": "28",
+  "averageExecutionTime": "498.27282142857115",
+  "averageScriptExecutionTime": "498.27282142857115"
+}, {
+  "canonicalDomain": "*.turnto.com",
+  "totalExecutionTime": "4099.7769999999991",
+  "totalOccurrences": "28",
+  "totalScripts": "30",
+  "averageExecutionTime": "146.42060714285714",
+  "averageScriptExecutionTime": "140.13215476190473"
+}, {
+  "canonicalDomain": "*.convertlanguage.com",
+  "totalExecutionTime": "1540.2559999999999",
+  "totalOccurrences": "28",
+  "totalScripts": "28",
+  "averageExecutionTime": "55.009142857142855",
+  "averageScriptExecutionTime": "55.009142857142855"
+}, {
+  "canonicalDomain": "*.segmanta.com",
+  "totalExecutionTime": "12352.166999999985",
+  "totalOccurrences": "28",
+  "totalScripts": "29",
+  "averageExecutionTime": "441.14882142857084",
+  "averageScriptExecutionTime": "428.46423214285653"
+}, {
+  "canonicalDomain": "*.directededge.com",
+  "totalExecutionTime": "1903.7060000000001",
+  "totalOccurrences": "28",
+  "totalScripts": "28",
+  "averageExecutionTime": "67.9895",
+  "averageScriptExecutionTime": "67.9895"
+}, {
+  "canonicalDomain": "*.ivitrack.com",
+  "totalExecutionTime": "2765.254",
+  "totalOccurrences": "28",
+  "totalScripts": "28",
+  "averageExecutionTime": "98.759071428571445",
+  "averageScriptExecutionTime": "98.759071428571445"
+}, {
+  "canonicalDomain": "*.loop11.com",
+  "totalExecutionTime": "16869.172999999981",
+  "totalOccurrences": "27",
+  "totalScripts": "27",
+  "averageExecutionTime": "624.78418518518447",
+  "averageScriptExecutionTime": "624.78418518518447"
+}, {
+  "canonicalDomain": "*.shopgate.com",
+  "totalExecutionTime": "12577.130999999988",
+  "totalOccurrences": "27",
+  "totalScripts": "77",
+  "averageExecutionTime": "465.81966666666619",
+  "averageScriptExecutionTime": "166.52029320987643"
+}, {
+  "canonicalDomain": "*.cloudsponge.com",
+  "totalExecutionTime": "3119.059",
+  "totalOccurrences": "27",
+  "totalScripts": "27",
+  "averageExecutionTime": "115.52070370370369",
+  "averageScriptExecutionTime": "115.52070370370369"
+}, {
+  "canonicalDomain": "*.barilliance.net",
+  "totalExecutionTime": "6380.625",
+  "totalOccurrences": "27",
+  "totalScripts": "27",
+  "averageExecutionTime": "236.31944444444446",
+  "averageScriptExecutionTime": "236.31944444444446"
+}, {
+  "canonicalDomain": "*.borderfree.com",
+  "totalExecutionTime": "8543.5559999999878",
+  "totalOccurrences": "27",
+  "totalScripts": "28",
+  "averageExecutionTime": "316.42799999999966",
+  "averageScriptExecutionTime": "310.81912962962923"
+}, {
+  "canonicalDomain": "static.polldaddy.com",
+  "totalExecutionTime": "1484.9320000000005",
+  "totalOccurrences": "27",
+  "totalScripts": "31",
+  "averageExecutionTime": "54.997481481481486",
+  "averageScriptExecutionTime": "44.685268518518534"
+}, {
+  "canonicalDomain": "*.smarterhq.io",
+  "totalExecutionTime": "2835.6369999999979",
+  "totalOccurrences": "26",
+  "totalScripts": "27",
+  "averageExecutionTime": "109.06296153846147",
+  "averageScriptExecutionTime": "106.65440384615376"
+}, {
+  "canonicalDomain": "*.smartclip.net",
+  "totalExecutionTime": "56405.0459999991",
+  "totalOccurrences": "26",
+  "totalScripts": "50",
+  "averageExecutionTime": "2169.4248461538109",
+  "averageScriptExecutionTime": "1086.5649230769056"
+}, {
+  "canonicalDomain": "*.globalsign.com",
+  "totalExecutionTime": "4180.5489999999972",
+  "totalOccurrences": "26",
+  "totalScripts": "31",
+  "averageExecutionTime": "160.79034615384606",
+  "averageScriptExecutionTime": "69.060446153846144"
+}, {
+  "canonicalDomain": "*.2o7.net",
+  "totalExecutionTime": "1886.1059999999998",
+  "totalOccurrences": "25",
+  "totalScripts": "27",
+  "averageExecutionTime": "75.444240000000008",
+  "averageScriptExecutionTime": "71.025720000000021"
+}, {
+  "canonicalDomain": "*.tru.am",
+  "totalExecutionTime": "1900.4689999999994",
+  "totalOccurrences": "25",
+  "totalScripts": "27",
+  "averageExecutionTime": "76.018759999999986",
+  "averageScriptExecutionTime": "72.038619999999966"
+}, {
+  "canonicalDomain": "*.adrecover.com",
+  "totalExecutionTime": "1193.013",
+  "totalOccurrences": "25",
+  "totalScripts": "25",
+  "averageExecutionTime": "47.720520000000008",
+  "averageScriptExecutionTime": "47.720520000000008"
+}, {
+  "canonicalDomain": "*.justpremium.com",
+  "totalExecutionTime": "891.1049999999999",
+  "totalOccurrences": "25",
+  "totalScripts": "26",
+  "averageExecutionTime": "35.644200000000012",
+  "averageScriptExecutionTime": "34.214040000000004"
+}, {
+  "canonicalDomain": "*.targito.com",
+  "totalExecutionTime": "2602.9059999999986",
+  "totalOccurrences": "25",
+  "totalScripts": "26",
+  "averageExecutionTime": "104.11623999999996",
+  "averageScriptExecutionTime": "100.63137999999996"
+}, {
+  "canonicalDomain": "*.syn-finity.com",
+  "totalExecutionTime": "4859.3510000000006",
+  "totalOccurrences": "25",
+  "totalScripts": "49",
+  "averageExecutionTime": "194.37403999999998",
+  "averageScriptExecutionTime": "101.53906666666664"
+}, {
+  "canonicalDomain": "*.sitegainer.com",
+  "totalExecutionTime": "42648.278999999529",
+  "totalOccurrences": "24",
+  "totalScripts": "24",
+  "averageExecutionTime": "1777.011624999981",
+  "averageScriptExecutionTime": "1777.011624999981"
+}, {
+  "canonicalDomain": "*.channeladvisor.com",
+  "totalExecutionTime": "1833.7649999999999",
+  "totalOccurrences": "24",
+  "totalScripts": "24",
+  "averageExecutionTime": "76.406874999999985",
+  "averageScriptExecutionTime": "76.406874999999985"
+}, {
+  "canonicalDomain": "*.box.com",
+  "totalExecutionTime": "141.357",
+  "totalOccurrences": "23",
+  "totalScripts": "38",
+  "averageExecutionTime": "6.1459565217391292",
+  "averageScriptExecutionTime": "3.4944836956521734"
+}, {
+  "canonicalDomain": "*.flix360.com",
+  "totalExecutionTime": "25449.101999999973",
+  "totalOccurrences": "23",
+  "totalScripts": "48",
+  "averageExecutionTime": "1106.4826956521727",
+  "averageScriptExecutionTime": "515.03560144927474"
+}, {
+  "canonicalDomain": "*.acq.io",
+  "totalExecutionTime": "1378.543",
+  "totalOccurrences": "23",
+  "totalScripts": "23",
+  "averageExecutionTime": "59.936652173913053",
+  "averageScriptExecutionTime": "59.936652173913053"
+}, {
+  "canonicalDomain": "*.3dissue.com",
+  "totalExecutionTime": "38232.601000000228",
+  "totalOccurrences": "23",
+  "totalScripts": "68",
+  "averageExecutionTime": "1662.28700000001",
+  "averageScriptExecutionTime": "729.41454689441468"
+}, {
+  "canonicalDomain": "*.campaigner.com",
+  "totalExecutionTime": "5349.985999999999",
+  "totalOccurrences": "23",
+  "totalScripts": "61",
+  "averageExecutionTime": "232.60808695652167",
+  "averageScriptExecutionTime": "90.216450724637639"
+}, {
+  "canonicalDomain": "*.mmtro.com",
+  "totalExecutionTime": "3383.7419999999997",
+  "totalOccurrences": "23",
+  "totalScripts": "35",
+  "averageExecutionTime": "147.11921739130429",
+  "averageScriptExecutionTime": "88.936347826086944"
+}, {
+  "canonicalDomain": "*.adsniper.ru",
+  "totalExecutionTime": "6273.9419999999946",
+  "totalOccurrences": "23",
+  "totalScripts": "23",
+  "averageExecutionTime": "272.78008695652153",
+  "averageScriptExecutionTime": "272.78008695652153"
+}, {
+  "canonicalDomain": "*.drct2u.com",
+  "totalExecutionTime": "15155.335999999979",
+  "totalOccurrences": "22",
+  "totalScripts": "67",
+  "averageExecutionTime": "688.87890909090811",
+  "averageScriptExecutionTime": "221.58208106060576"
+}, {
+  "canonicalDomain": "*.mediaforge.com",
+  "totalExecutionTime": "1447.0140000000001",
+  "totalOccurrences": "22",
+  "totalScripts": "22",
+  "averageExecutionTime": "65.773363636363641",
+  "averageScriptExecutionTime": "65.773363636363641"
+}, {
+  "canonicalDomain": "*.emetriq.de",
+  "totalExecutionTime": "2090.5619999999994",
+  "totalOccurrences": "22",
+  "totalScripts": "24",
+  "averageExecutionTime": "95.025545454545437",
+  "averageScriptExecutionTime": "90.435636363636348"
+}, {
+  "canonicalDomain": "*.navu.co",
+  "totalExecutionTime": "9473.3609999999589",
+  "totalOccurrences": "22",
+  "totalScripts": "22",
+  "averageExecutionTime": "430.60731818181625",
+  "averageScriptExecutionTime": "430.60731818181625"
+}, {
+  "canonicalDomain": "*.skyglue.com",
+  "totalExecutionTime": "2257.268",
+  "totalOccurrences": "22",
+  "totalScripts": "26",
+  "averageExecutionTime": "102.60309090909094",
+  "averageScriptExecutionTime": "88.619590909090917"
+}, {
+  "canonicalDomain": "*.granify.com",
+  "totalExecutionTime": "18351.538999999942",
+  "totalOccurrences": "22",
+  "totalScripts": "32",
+  "averageExecutionTime": "834.16086363636111",
+  "averageScriptExecutionTime": "701.11949999999808"
+}, {
+  "canonicalDomain": "*.rebelmouse.com",
+  "totalExecutionTime": "4292.759999999982",
+  "totalOccurrences": "22",
+  "totalScripts": "25",
+  "averageExecutionTime": "195.12545454545375",
+  "averageScriptExecutionTime": "136.82301136363574"
+}, {
+  "canonicalDomain": "*.anedot.com",
+  "totalExecutionTime": "79482.228999999643",
+  "totalOccurrences": "22",
+  "totalScripts": "92",
+  "averageExecutionTime": "3612.8285909090746",
+  "averageScriptExecutionTime": "820.14465833332963"
+}, {
+  "canonicalDomain": "*.cooladata.com",
+  "totalExecutionTime": "1181.642",
+  "totalOccurrences": "21",
+  "totalScripts": "21",
+  "averageExecutionTime": "56.268666666666668",
+  "averageScriptExecutionTime": "56.268666666666668"
+}, {
+  "canonicalDomain": "*.gravatar.com",
+  "totalExecutionTime": "5197.7009999999864",
+  "totalOccurrences": "21",
+  "totalScripts": "26",
+  "averageExecutionTime": "247.50957142857069",
+  "averageScriptExecutionTime": "129.69554761904729"
+}, {
+  "canonicalDomain": "*.exactag.com",
+  "totalExecutionTime": "1834.4880000000005",
+  "totalOccurrences": "21",
+  "totalScripts": "21",
+  "averageExecutionTime": "87.356571428571442",
+  "averageScriptExecutionTime": "87.356571428571442"
+}, {
+  "canonicalDomain": "*.adserver01.de",
+  "totalExecutionTime": "1324.5859999999996",
+  "totalOccurrences": "21",
+  "totalScripts": "26",
+  "averageExecutionTime": "63.075523809523773",
+  "averageScriptExecutionTime": "50.105976190476177"
+}, {
+  "canonicalDomain": "*.soundestlink.com",
+  "totalExecutionTime": "1138.595",
+  "totalOccurrences": "21",
+  "totalScripts": "21",
+  "averageExecutionTime": "54.218809523809526",
+  "averageScriptExecutionTime": "54.218809523809526"
+}, {
+  "canonicalDomain": "*.sailthru.com",
+  "totalExecutionTime": "4292.9439999999995",
+  "totalOccurrences": "20",
+  "totalScripts": "20",
+  "averageExecutionTime": "214.64719999999991",
+  "averageScriptExecutionTime": "214.64719999999991"
+}, {
+  "canonicalDomain": "*.bam-x.com",
+  "totalExecutionTime": "1619.5770000000005",
+  "totalOccurrences": "20",
+  "totalScripts": "20",
+  "averageExecutionTime": "80.978850000000008",
+  "averageScriptExecutionTime": "80.978850000000008"
+}, {
+  "canonicalDomain": "*.condenastdigital.com",
+  "totalExecutionTime": "3789.2009999999987",
+  "totalOccurrences": "20",
+  "totalScripts": "20",
+  "averageExecutionTime": "189.46004999999994",
+  "averageScriptExecutionTime": "189.46004999999994"
+}, {
+  "canonicalDomain": "*.mirror.co.uk",
+  "totalExecutionTime": "4813.9609999999784",
+  "totalOccurrences": "20",
+  "totalScripts": "30",
+  "averageExecutionTime": "240.69804999999894",
+  "averageScriptExecutionTime": "102.57154999999993"
+}, {
+  "canonicalDomain": "*.co-buying.com",
+  "totalExecutionTime": "3135.5849999999959",
+  "totalOccurrences": "19",
+  "totalScripts": "24",
+  "averageExecutionTime": "165.030789473684",
+  "averageScriptExecutionTime": "99.875578947368311"
+}, {
+  "canonicalDomain": "*.template-help.com",
+  "totalExecutionTime": "13800.536",
+  "totalOccurrences": "19",
+  "totalScripts": "38",
+  "averageExecutionTime": "726.34399999999982",
+  "averageScriptExecutionTime": "290.63090526315773"
+}, {
+  "canonicalDomain": "*.cpx.to",
+  "totalExecutionTime": "948.47600000000011",
+  "totalOccurrences": "19",
+  "totalScripts": "19",
+  "averageExecutionTime": "49.919789473684212",
+  "averageScriptExecutionTime": "49.919789473684212"
+}, {
+  "canonicalDomain": "*.evolvemediallc.com",
+  "totalExecutionTime": "6773.9189999999717",
+  "totalOccurrences": "19",
+  "totalScripts": "19",
+  "averageExecutionTime": "356.52205263157748",
+  "averageScriptExecutionTime": "356.52205263157748"
+}, {
+  "canonicalDomain": "*.petametrics.com",
+  "totalExecutionTime": "19124.698000000008",
+  "totalOccurrences": "19",
+  "totalScripts": "19",
+  "averageExecutionTime": "1006.5630526315791",
+  "averageScriptExecutionTime": "1006.5630526315791"
+}, {
+  "canonicalDomain": "*.aimatch.com",
+  "totalExecutionTime": "17638.976999999904",
+  "totalOccurrences": "18",
+  "totalScripts": "59",
+  "averageExecutionTime": "979.94316666666145",
+  "averageScriptExecutionTime": "249.04329953703569"
+}, {
+  "canonicalDomain": "*.intentiq.com",
+  "totalExecutionTime": "4440.2159999999967",
+  "totalOccurrences": "18",
+  "totalScripts": "18",
+  "averageExecutionTime": "246.67866666666652",
+  "averageScriptExecutionTime": "246.67866666666652"
+}, {
+  "canonicalDomain": "*.message-business.com",
+  "totalExecutionTime": "5557.5099999999966",
+  "totalOccurrences": "18",
+  "totalScripts": "31",
+  "averageExecutionTime": "308.75055555555537",
+  "averageScriptExecutionTime": "196.56687037037025"
+}, {
+  "canonicalDomain": "*.adventori.com",
+  "totalExecutionTime": "7952.0549999999994",
+  "totalOccurrences": "18",
+  "totalScripts": "55",
+  "averageExecutionTime": "441.78083333333325",
+  "averageScriptExecutionTime": "134.66354537037037"
+}, {
+  "canonicalDomain": "*.finsburymedia.com",
+  "totalExecutionTime": "2983.301999999997",
+  "totalOccurrences": "17",
+  "totalScripts": "20",
+  "averageExecutionTime": "175.48835294117634",
+  "averageScriptExecutionTime": "155.69908823529397"
+}, {
+  "canonicalDomain": "*.10cms.com",
+  "totalExecutionTime": "4123.6229999999987",
+  "totalOccurrences": "17",
+  "totalScripts": "19",
+  "averageExecutionTime": "242.56605882352932",
+  "averageScriptExecutionTime": "145.13141176470586"
+}, {
+  "canonicalDomain": "*.pepperjam.com",
+  "totalExecutionTime": "8197.5900000000456",
+  "totalOccurrences": "17",
+  "totalScripts": "17",
+  "averageExecutionTime": "482.21117647059077",
+  "averageScriptExecutionTime": "482.21117647059077"
+}, {
+  "canonicalDomain": "*.hitslink.com",
+  "totalExecutionTime": "848.4319999999999",
+  "totalOccurrences": "17",
+  "totalScripts": "17",
+  "averageExecutionTime": "49.907764705882357",
+  "averageScriptExecutionTime": "49.907764705882357"
+}, {
+  "canonicalDomain": "*.247-inc.net",
+  "totalExecutionTime": "18966.427999999964",
+  "totalOccurrences": "17",
+  "totalScripts": "45",
+  "averageExecutionTime": "1115.6722352941154",
+  "averageScriptExecutionTime": "468.73475196078363"
+}, {
+  "canonicalDomain": "*.divido.com",
+  "totalExecutionTime": "7514.6219999999812",
+  "totalOccurrences": "16",
+  "totalScripts": "16",
+  "averageExecutionTime": "469.66387499999882",
+  "averageScriptExecutionTime": "469.66387499999882"
+}, {
+  "canonicalDomain": "*.emxdgt.com",
+  "totalExecutionTime": "884.68000000000029",
+  "totalOccurrences": "16",
+  "totalScripts": "16",
+  "averageExecutionTime": "55.292500000000018",
+  "averageScriptExecutionTime": "55.292500000000018"
+}, {
+  "canonicalDomain": "*.creative-serving.com",
+  "totalExecutionTime": "2477.5339999999997",
+  "totalOccurrences": "16",
+  "totalScripts": "16",
+  "averageExecutionTime": "154.84587499999995",
+  "averageScriptExecutionTime": "154.84587499999995"
+}, {
+  "canonicalDomain": "*.vizury.com",
+  "totalExecutionTime": "947.67500000000041",
+  "totalOccurrences": "16",
+  "totalScripts": "17",
+  "averageExecutionTime": "59.229687500000011",
+  "averageScriptExecutionTime": "57.828843750000011"
+}, {
+  "canonicalDomain": "*.fospha.com",
+  "totalExecutionTime": "1150.507",
+  "totalOccurrences": "16",
+  "totalScripts": "16",
+  "averageExecutionTime": "71.906687500000018",
+  "averageScriptExecutionTime": "71.906687500000018"
+}, {
+  "canonicalDomain": "*.segmentstream.com",
+  "totalExecutionTime": "9588.2139999999617",
+  "totalOccurrences": "16",
+  "totalScripts": "16",
+  "averageExecutionTime": "599.2633749999975",
+  "averageScriptExecutionTime": "599.2633749999975"
+}, {
+  "canonicalDomain": "*.psyma.com",
+  "totalExecutionTime": "335.30800000000011",
+  "totalOccurrences": "16",
+  "totalScripts": "16",
+  "averageExecutionTime": "20.956750000000003",
+  "averageScriptExecutionTime": "20.956750000000003"
+}, {
+  "canonicalDomain": "*.idio.co",
+  "totalExecutionTime": "3289.1349999999939",
+  "totalOccurrences": "16",
+  "totalScripts": "19",
+  "averageExecutionTime": "205.57093749999962",
+  "averageScriptExecutionTime": "185.81049999999962"
+}, {
+  "canonicalDomain": "*.inskinad.com",
+  "totalExecutionTime": "5799.8689999999915",
+  "totalOccurrences": "15",
+  "totalScripts": "30",
+  "averageExecutionTime": "386.65793333333283",
+  "averageScriptExecutionTime": "193.32896666666642"
+}, {
+  "canonicalDomain": "*.recruitmentplatform.com",
+  "totalExecutionTime": "9270.36199999999",
+  "totalOccurrences": "14",
+  "totalScripts": "17",
+  "averageExecutionTime": "662.1687142857138",
+  "averageScriptExecutionTime": "554.33574999999917"
+}, {
+  "canonicalDomain": "*.janrain.com",
+  "totalExecutionTime": "1755.2749999999992",
+  "totalOccurrences": "14",
+  "totalScripts": "16",
+  "averageExecutionTime": "125.37678571428566",
+  "averageScriptExecutionTime": "103.19940476190474"
+}, {
+  "canonicalDomain": "*.crsspxl.com",
+  "totalExecutionTime": "358.39800000000008",
+  "totalOccurrences": "14",
+  "totalScripts": "14",
+  "averageExecutionTime": "25.59985714285715",
+  "averageScriptExecutionTime": "25.59985714285715"
+}, {
+  "canonicalDomain": "*.adtpix.com",
+  "totalExecutionTime": "1071.9660000000008",
+  "totalOccurrences": "14",
+  "totalScripts": "14",
+  "averageExecutionTime": "76.569000000000045",
+  "averageScriptExecutionTime": "76.569000000000045"
+}, {
+  "canonicalDomain": "*.adtechjp.com",
+  "totalExecutionTime": "632.688",
+  "totalOccurrences": "14",
+  "totalScripts": "15",
+  "averageExecutionTime": "45.192",
+  "averageScriptExecutionTime": "41.201928571428574"
+}, {
+  "canonicalDomain": "*.goinstore.com",
+  "totalExecutionTime": "3132.1429999999973",
+  "totalOccurrences": "14",
+  "totalScripts": "17",
+  "averageExecutionTime": "223.72449999999975",
+  "averageScriptExecutionTime": "193.28432142857125"
+}, {
+  "canonicalDomain": "*.jotformpro.com",
+  "totalExecutionTime": "413.343",
+  "totalOccurrences": "14",
+  "totalScripts": "14",
+  "averageExecutionTime": "29.524500000000007",
+  "averageScriptExecutionTime": "29.524500000000007"
+}, {
+  "canonicalDomain": "*.sundaysky.com",
+  "totalExecutionTime": "10151.047000000022",
+  "totalOccurrences": "14",
+  "totalScripts": "14",
+  "averageExecutionTime": "725.07478571428726",
+  "averageScriptExecutionTime": "725.07478571428726"
+}, {
+  "canonicalDomain": "*.4finance.com",
+  "totalExecutionTime": "5979.0109999999731",
+  "totalOccurrences": "14",
+  "totalScripts": "17",
+  "averageExecutionTime": "427.07221428571228",
+  "averageScriptExecutionTime": "360.78417857142676"
+}, {
+  "canonicalDomain": "*.measured.com",
+  "totalExecutionTime": "1810.8079999999998",
+  "totalOccurrences": "14",
+  "totalScripts": "14",
+  "averageExecutionTime": "129.34342857142857",
+  "averageScriptExecutionTime": "129.34342857142857"
+}, {
+  "canonicalDomain": "*.aph.com",
+  "totalExecutionTime": "1607.4329999999991",
+  "totalOccurrences": "14",
+  "totalScripts": "19",
+  "averageExecutionTime": "114.81664285714281",
+  "averageScriptExecutionTime": "72.067535714285711"
+}, {
+  "canonicalDomain": "*.truefitcorp.com",
+  "totalExecutionTime": "1213.9470000000008",
+  "totalOccurrences": "13",
+  "totalScripts": "15",
+  "averageExecutionTime": "93.380538461538521",
+  "averageScriptExecutionTime": "73.221153846153882"
+}, {
+  "canonicalDomain": "*.glassdoor.com",
+  "totalExecutionTime": "7781.792999999986",
+  "totalOccurrences": "13",
+  "totalScripts": "39",
+  "averageExecutionTime": "598.59946153846067",
+  "averageScriptExecutionTime": "83.424851084812531"
+}, {
+  "canonicalDomain": "*.addtocalendar.com",
+  "totalExecutionTime": "1076.1540000000002",
+  "totalOccurrences": "13",
+  "totalScripts": "13",
+  "averageExecutionTime": "82.781076923076952",
+  "averageScriptExecutionTime": "82.781076923076952"
+}, {
+  "canonicalDomain": "*.doublepimp.com",
+  "totalExecutionTime": "2202.277",
+  "totalOccurrences": "13",
+  "totalScripts": "22",
+  "averageExecutionTime": "169.40592307692307",
+  "averageScriptExecutionTime": "98.8013076923077"
+}, {
+  "canonicalDomain": "*.channel.me",
+  "totalExecutionTime": "3462.2389999999996",
+  "totalOccurrences": "13",
+  "totalScripts": "27",
+  "averageExecutionTime": "266.32607692307687",
+  "averageScriptExecutionTime": "127.04739230769231"
+}, {
+  "canonicalDomain": "*.alphassl.com",
+  "totalExecutionTime": "1414.4389999999999",
+  "totalOccurrences": "13",
+  "totalScripts": "18",
+  "averageExecutionTime": "108.803",
+  "averageScriptExecutionTime": "71.755346153846148"
+}, {
+  "canonicalDomain": "*.yieldoptimizer.com",
+  "totalExecutionTime": "851.80700000000013",
+  "totalOccurrences": "13",
+  "totalScripts": "13",
+  "averageExecutionTime": "65.5236153846154",
+  "averageScriptExecutionTime": "65.5236153846154"
+}, {
+  "canonicalDomain": "*.y-track.com",
+  "totalExecutionTime": "806.681",
+  "totalOccurrences": "13",
+  "totalScripts": "13",
+  "averageExecutionTime": "62.052384615384611",
+  "averageScriptExecutionTime": "62.052384615384611"
+}, {
+  "canonicalDomain": "*.id-visitors.com",
+  "totalExecutionTime": "940.57400000000007",
+  "totalOccurrences": "13",
+  "totalScripts": "13",
+  "averageExecutionTime": "72.351846153846154",
+  "averageScriptExecutionTime": "72.351846153846154"
+}, {
+  "canonicalDomain": "*.adacado.com",
+  "totalExecutionTime": "853.136",
+  "totalOccurrences": "13",
+  "totalScripts": "16",
+  "averageExecutionTime": "65.625846153846169",
+  "averageScriptExecutionTime": "53.648461538461547"
+}, {
+  "canonicalDomain": "*.adunity.com",
+  "totalExecutionTime": "4368.296999999995",
+  "totalOccurrences": "13",
+  "totalScripts": "26",
+  "averageExecutionTime": "336.02284615384582",
+  "averageScriptExecutionTime": "190.06553205128182"
+}, {
+  "canonicalDomain": "*.zemanta.com",
+  "totalExecutionTime": "852.9699999999973",
+  "totalOccurrences": "12",
+  "totalScripts": "12",
+  "averageExecutionTime": "71.080833333333118",
+  "averageScriptExecutionTime": "71.080833333333118"
+}, {
+  "canonicalDomain": "*.cnbc.com",
+  "totalExecutionTime": "12715.535999999986",
+  "totalOccurrences": "12",
+  "totalScripts": "51",
+  "averageExecutionTime": "1059.6279999999986",
+  "averageScriptExecutionTime": "247.15548181216911"
+}, {
+  "canonicalDomain": "*.crowdskout.com",
+  "totalExecutionTime": "1109.6170000000006",
+  "totalOccurrences": "12",
+  "totalScripts": "13",
+  "averageExecutionTime": "92.468083333333382",
+  "averageScriptExecutionTime": "88.218166666666718"
+}, {
+  "canonicalDomain": "*.comodo.com",
+  "totalExecutionTime": "9773.3479999999981",
+  "totalOccurrences": "12",
+  "totalScripts": "19",
+  "averageExecutionTime": "814.44566666666651",
+  "averageScriptExecutionTime": "119.63434374999996"
+}, {
+  "canonicalDomain": "*.wzrkt.com",
+  "totalExecutionTime": "787.5450000000003",
+  "totalOccurrences": "12",
+  "totalScripts": "12",
+  "averageExecutionTime": "65.628750000000025",
+  "averageScriptExecutionTime": "65.628750000000025"
+}, {
+  "canonicalDomain": "*.recobell.io",
+  "totalExecutionTime": "745.692",
+  "totalOccurrences": "12",
+  "totalScripts": "12",
+  "averageExecutionTime": "62.141000000000005",
+  "averageScriptExecutionTime": "62.141000000000005"
+}, {
+  "canonicalDomain": "*.developermedia.com",
+  "totalExecutionTime": "2716.524999999996",
+  "totalOccurrences": "12",
+  "totalScripts": "12",
+  "averageExecutionTime": "226.37708333333302",
+  "averageScriptExecutionTime": "226.37708333333302"
+}, {
+  "canonicalDomain": "*.accentuate.io",
+  "totalExecutionTime": "1019.6209999999999",
+  "totalOccurrences": "11",
+  "totalScripts": "11",
+  "averageExecutionTime": "92.692818181818168",
+  "averageScriptExecutionTime": "92.692818181818168"
+}, {
+  "canonicalDomain": "*.datahc.com",
+  "totalExecutionTime": "1021.4039999999976",
+  "totalOccurrences": "11",
+  "totalScripts": "11",
+  "averageExecutionTime": "92.85490909090889",
+  "averageScriptExecutionTime": "92.85490909090889"
+}, {
+  "canonicalDomain": "*.indeed.com",
+  "totalExecutionTime": "9027.96300000037",
+  "totalOccurrences": "11",
+  "totalScripts": "15",
+  "averageExecutionTime": "820.7239090909427",
+  "averageScriptExecutionTime": "308.71475757576854"
+}, {
+  "canonicalDomain": "*.ispot.tv",
+  "totalExecutionTime": "487.62199999999916",
+  "totalOccurrences": "11",
+  "totalScripts": "16",
+  "averageExecutionTime": "44.329272727272645",
+  "averageScriptExecutionTime": "26.47126515151513"
+}, {
+  "canonicalDomain": "*.webtrends.com",
+  "totalExecutionTime": "659.96499999999992",
+  "totalOccurrences": "11",
+  "totalScripts": "11",
+  "averageExecutionTime": "59.996818181818178",
+  "averageScriptExecutionTime": "59.996818181818178"
+}, {
+  "canonicalDomain": "*.adspeed.net",
+  "totalExecutionTime": "4768.7979999999943",
+  "totalOccurrences": "11",
+  "totalScripts": "54",
+  "averageExecutionTime": "433.5270909090903",
+  "averageScriptExecutionTime": "96.933945075757535"
+}, {
+  "canonicalDomain": "*.crowdtwist.com",
+  "totalExecutionTime": "5259.396000000057",
+  "totalOccurrences": "11",
+  "totalScripts": "12",
+  "averageExecutionTime": "478.1269090909143",
+  "averageScriptExecutionTime": "311.323136363639"
+}, {
+  "canonicalDomain": "*.dstillery.com",
+  "totalExecutionTime": "147.46400000000014",
+  "totalOccurrences": "11",
+  "totalScripts": "11",
+  "averageExecutionTime": "13.405818181818196",
+  "averageScriptExecutionTime": "13.405818181818196"
+}, {
+  "canonicalDomain": "*.webphone.net",
+  "totalExecutionTime": "1739.9749999999988",
+  "totalOccurrences": "11",
+  "totalScripts": "15",
+  "averageExecutionTime": "158.17954545454535",
+  "averageScriptExecutionTime": "120.20577272727265"
+}, {
+  "canonicalDomain": "*.mol.im",
+  "totalExecutionTime": "44291.731000000553",
+  "totalOccurrences": "11",
+  "totalScripts": "67",
+  "averageExecutionTime": "4026.5210000000498",
+  "averageScriptExecutionTime": "421.86648429487769"
+}, {
+  "canonicalDomain": "*.w55c.net",
+  "totalExecutionTime": "0.20500000000000007",
+  "totalOccurrences": "10",
+  "totalScripts": "10",
+  "averageExecutionTime": "0.020500000000000008",
+  "averageScriptExecutionTime": "0.020500000000000008"
+}, {
+  "canonicalDomain": "*.tinyurl.com",
+  "totalExecutionTime": "3200.1950000000088",
+  "totalOccurrences": "10",
+  "totalScripts": "13",
+  "averageExecutionTime": "320.01950000000085",
+  "averageScriptExecutionTime": "137.00930000000022"
+}, {
+  "canonicalDomain": "*.algolianet.com",
+  "totalExecutionTime": "7260.7589999999827",
+  "totalOccurrences": "10",
+  "totalScripts": "14",
+  "averageExecutionTime": "726.07589999999811",
+  "averageScriptExecutionTime": "577.08723333333228"
+}, {
+  "canonicalDomain": "*.tpmn.co.kr",
+  "totalExecutionTime": "387.702",
+  "totalOccurrences": "10",
+  "totalScripts": "17",
+  "averageExecutionTime": "38.7702",
+  "averageScriptExecutionTime": "19.56715"
+}, {
+  "canonicalDomain": "*.bitgravity.com",
+  "totalExecutionTime": "6006.7389999999932",
+  "totalOccurrences": "10",
+  "totalScripts": "30",
+  "averageExecutionTime": "600.67389999999932",
+  "averageScriptExecutionTime": "168.72207499999985"
+}, {
+  "canonicalDomain": "*.bwbx.io",
+  "totalExecutionTime": "64031.170999999995",
+  "totalOccurrences": "10",
+  "totalScripts": "93",
+  "averageExecutionTime": "6403.1170999999995",
+  "averageScriptExecutionTime": "838.70804116246256"
+}, {
+  "canonicalDomain": "*.brealtime.com",
+  "totalExecutionTime": "1155.7619999999997",
+  "totalOccurrences": "10",
+  "totalScripts": "10",
+  "averageExecutionTime": "115.5762",
+  "averageScriptExecutionTime": "115.5762"
+}, {
+  "canonicalDomain": "*.1dmp.io",
+  "totalExecutionTime": "1895.5209999999981",
+  "totalOccurrences": "10",
+  "totalScripts": "10",
+  "averageExecutionTime": "189.55209999999983",
+  "averageScriptExecutionTime": "189.55209999999983"
+}, {
+  "canonicalDomain": "*.goadservices.com",
+  "totalExecutionTime": "802.99900000000059",
+  "totalOccurrences": "9",
+  "totalScripts": "14",
+  "averageExecutionTime": "89.222111111111175",
+  "averageScriptExecutionTime": "59.065277777777844"
+}, {
+  "canonicalDomain": "*.worldpay.com",
+  "totalExecutionTime": "7111.2119999999968",
+  "totalOccurrences": "9",
+  "totalScripts": "16",
+  "averageExecutionTime": "790.13466666666636",
+  "averageScriptExecutionTime": "232.510097222222"
+}, {
+  "canonicalDomain": "*.nowinteract.com",
+  "totalExecutionTime": "1170.5799999999983",
+  "totalOccurrences": "9",
+  "totalScripts": "9",
+  "averageExecutionTime": "130.06444444444426",
+  "averageScriptExecutionTime": "130.06444444444426"
+}, {
+  "canonicalDomain": "*.metoffice.gov.uk",
+  "totalExecutionTime": "1860.0250000000005",
+  "totalOccurrences": "9",
+  "totalScripts": "21",
+  "averageExecutionTime": "206.66944444444454",
+  "averageScriptExecutionTime": "29.536492063492073"
+}, {
+  "canonicalDomain": "*.snidigital.com",
+  "totalExecutionTime": "8056.1589999999951",
+  "totalOccurrences": "9",
+  "totalScripts": "13",
+  "averageExecutionTime": "895.12877777777726",
+  "averageScriptExecutionTime": "679.58799999999917"
+}, {
+  "canonicalDomain": "*.twitframe.com",
+  "totalExecutionTime": "1166.2229999999963",
+  "totalOccurrences": "9",
+  "totalScripts": "15",
+  "averageExecutionTime": "129.58033333333293",
+  "averageScriptExecutionTime": "45.532711111111006"
+}, {
+  "canonicalDomain": "*.hull.io",
+  "totalExecutionTime": "3010.8909999999923",
+  "totalOccurrences": "9",
+  "totalScripts": "9",
+  "averageExecutionTime": "334.54344444444365",
+  "averageScriptExecutionTime": "334.54344444444365"
+}, {
+  "canonicalDomain": "*.coherentpath.com",
+  "totalExecutionTime": "770.74200000000008",
+  "totalOccurrences": "9",
+  "totalScripts": "9",
+  "averageExecutionTime": "85.638000000000019",
+  "averageScriptExecutionTime": "85.638000000000019"
+}, {
+  "canonicalDomain": "*.lfstmedia.com",
+  "totalExecutionTime": "4844.8550000000159",
+  "totalOccurrences": "9",
+  "totalScripts": "23",
+  "averageExecutionTime": "538.31722222222413",
+  "averageScriptExecutionTime": "87.894829629629825"
+}, {
+  "canonicalDomain": "*.airpr.com",
+  "totalExecutionTime": "1098.2909999999988",
+  "totalOccurrences": "8",
+  "totalScripts": "8",
+  "averageExecutionTime": "137.28637499999985",
+  "averageScriptExecutionTime": "137.28637499999985"
+}, {
+  "canonicalDomain": "*.castle.io",
+  "totalExecutionTime": "4300.4279999999981",
+  "totalOccurrences": "8",
+  "totalScripts": "8",
+  "averageExecutionTime": "537.55349999999976",
+  "averageScriptExecutionTime": "537.55349999999976"
+}, {
+  "canonicalDomain": "*.siteblindado.com",
+  "totalExecutionTime": "1541.0229999999935",
+  "totalOccurrences": "8",
+  "totalScripts": "9",
+  "averageExecutionTime": "192.62787499999919",
+  "averageScriptExecutionTime": "124.61293749999959"
+}, {
+  "canonicalDomain": "*.a3cloud.net",
+  "totalExecutionTime": "965.02100000000019",
+  "totalOccurrences": "8",
+  "totalScripts": "8",
+  "averageExecutionTime": "120.62762500000002",
+  "averageScriptExecutionTime": "120.62762500000002"
+}, {
+  "canonicalDomain": "*.inzynk.com",
+  "totalExecutionTime": "425.80199999999996",
+  "totalOccurrences": "8",
+  "totalScripts": "9",
+  "averageExecutionTime": "53.22525",
+  "averageScriptExecutionTime": "47.127250000000004"
+}, {
+  "canonicalDomain": "*.adtrue.com",
+  "totalExecutionTime": "3698.7099999999914",
+  "totalOccurrences": "8",
+  "totalScripts": "16",
+  "averageExecutionTime": "462.33874999999892",
+  "averageScriptExecutionTime": "222.11687499999948"
+}, {
+  "canonicalDomain": "*.emerse.com",
+  "totalExecutionTime": "3232.1239999999948",
+  "totalOccurrences": "8",
+  "totalScripts": "9",
+  "averageExecutionTime": "404.01549999999935",
+  "averageScriptExecutionTime": "391.93524999999937"
+}, {
+  "canonicalDomain": "*.affectv.com",
+  "totalExecutionTime": "315.49100000000004",
+  "totalOccurrences": "8",
+  "totalScripts": "8",
+  "averageExecutionTime": "39.436375000000005",
+  "averageScriptExecutionTime": "39.436375000000005"
+}, {
+  "canonicalDomain": "*.extole.com",
+  "totalExecutionTime": "1811.1739999999984",
+  "totalOccurrences": "8",
+  "totalScripts": "8",
+  "averageExecutionTime": "226.3967499999998",
+  "averageScriptExecutionTime": "226.3967499999998"
+}, {
+  "canonicalDomain": "*.sumologic.com",
+  "totalExecutionTime": "3677.4459999999895",
+  "totalOccurrences": "8",
+  "totalScripts": "8",
+  "averageExecutionTime": "459.68074999999868",
+  "averageScriptExecutionTime": "459.68074999999868"
+}, {
+  "canonicalDomain": "*.xg4ken.com",
+  "totalExecutionTime": "314.81100000000004",
+  "totalOccurrences": "8",
+  "totalScripts": "8",
+  "averageExecutionTime": "39.351375000000004",
+  "averageScriptExecutionTime": "39.351375000000004"
+}, {
+  "canonicalDomain": "*.certona.net",
+  "totalExecutionTime": "653.0859999999999",
+  "totalOccurrences": "7",
+  "totalScripts": "8",
+  "averageExecutionTime": "93.297999999999988",
+  "averageScriptExecutionTime": "84.102571428571423"
+}, {
+  "canonicalDomain": "*.audienceiq.com",
+  "totalExecutionTime": "2733.5259999999921",
+  "totalOccurrences": "7",
+  "totalScripts": "7",
+  "averageExecutionTime": "390.50371428571316",
+  "averageScriptExecutionTime": "390.50371428571316"
+}, {
+  "canonicalDomain": "*.ekomi.com",
+  "totalExecutionTime": "2257.6419999999644",
+  "totalOccurrences": "7",
+  "totalScripts": "12",
+  "averageExecutionTime": "322.52028571428059",
+  "averageScriptExecutionTime": "191.60992857142759"
+}, {
+  "canonicalDomain": "*.pricerunner.com",
+  "totalExecutionTime": "5320.13700000009",
+  "totalOccurrences": "7",
+  "totalScripts": "18",
+  "averageExecutionTime": "760.01957142858441",
+  "averageScriptExecutionTime": "202.50731428571751"
+}, {
+  "canonicalDomain": "*.inbenta.com",
+  "totalExecutionTime": "613.45200000000057",
+  "totalOccurrences": "7",
+  "totalScripts": "7",
+  "averageExecutionTime": "87.636000000000081",
+  "averageScriptExecutionTime": "87.636000000000081"
+}, {
+  "canonicalDomain": "*.resultslist.com",
+  "totalExecutionTime": "676.173",
+  "totalOccurrences": "7",
+  "totalScripts": "10",
+  "averageExecutionTime": "96.596142857142851",
+  "averageScriptExecutionTime": "64.140738095238092"
+}, {
+  "canonicalDomain": "*.bufferapp.com",
+  "totalExecutionTime": "884.06199999999944",
+  "totalOccurrences": "7",
+  "totalScripts": "7",
+  "averageExecutionTime": "126.29457142857134",
+  "averageScriptExecutionTime": "126.29457142857134"
+}, {
+  "canonicalDomain": "*.trychameleon.com",
+  "totalExecutionTime": "20897.952000000063",
+  "totalOccurrences": "7",
+  "totalScripts": "13",
+  "averageExecutionTime": "2985.4217142857242",
+  "averageScriptExecutionTime": "1209.1729761904785"
+}, {
+  "canonicalDomain": "*.vouchedfor.co.uk",
+  "totalExecutionTime": "89.745",
+  "totalOccurrences": "7",
+  "totalScripts": "7",
+  "averageExecutionTime": "12.820714285714287",
+  "averageScriptExecutionTime": "12.820714285714287"
+}, {
+  "canonicalDomain": "*.sotic.net",
+  "totalExecutionTime": "5764.5529999999844",
+  "totalOccurrences": "7",
+  "totalScripts": "10",
+  "averageExecutionTime": "823.50757142856924",
+  "averageScriptExecutionTime": "602.65864285714144"
+}, {
+  "canonicalDomain": "*.viamichelin.com",
+  "totalExecutionTime": "1220.9339999999995",
+  "totalOccurrences": "7",
+  "totalScripts": "10",
+  "averageExecutionTime": "174.41914285714279",
+  "averageScriptExecutionTime": "105.3633571428571"
+}, {
+  "canonicalDomain": "*.boxever.com",
+  "totalExecutionTime": "4399.4590000000881",
+  "totalOccurrences": "7",
+  "totalScripts": "7",
+  "averageExecutionTime": "628.49414285715545",
+  "averageScriptExecutionTime": "628.49414285715545"
+}, {
+  "canonicalDomain": "*.adblade.com",
+  "totalExecutionTime": "382.306",
+  "totalOccurrences": "7",
+  "totalScripts": "9",
+  "averageExecutionTime": "54.615142857142857",
+  "averageScriptExecutionTime": "47.1272380952381"
+}, {
+  "canonicalDomain": "*.isitetv.com",
+  "totalExecutionTime": "917.08099999999945",
+  "totalOccurrences": "7",
+  "totalScripts": "8",
+  "averageExecutionTime": "131.01157142857136",
+  "averageScriptExecutionTime": "126.3346428571428"
+}, {
+  "canonicalDomain": "*.avmws.com",
+  "totalExecutionTime": "495.80999999999983",
+  "totalOccurrences": "7",
+  "totalScripts": "7",
+  "averageExecutionTime": "70.829999999999984",
+  "averageScriptExecutionTime": "70.829999999999984"
+}, {
+  "canonicalDomain": "*.firepush.io",
+  "totalExecutionTime": "446.334",
+  "totalOccurrences": "7",
+  "totalScripts": "7",
+  "averageExecutionTime": "63.762",
+  "averageScriptExecutionTime": "63.762"
+}, {
+  "canonicalDomain": "*.sportradarserving.com",
+  "totalExecutionTime": "361.63900000000007",
+  "totalOccurrences": "7",
+  "totalScripts": "7",
+  "averageExecutionTime": "51.662714285714294",
+  "averageScriptExecutionTime": "51.662714285714294"
+}, {
+  "canonicalDomain": "*.eccmp.com",
+  "totalExecutionTime": "308.559",
+  "totalOccurrences": "7",
+  "totalScripts": "7",
+  "averageExecutionTime": "44.079857142857144",
+  "averageScriptExecutionTime": "44.079857142857144"
+}, {
+  "canonicalDomain": "*.wurflcloud.com",
+  "totalExecutionTime": "748.07299999999964",
+  "totalOccurrences": "6",
+  "totalScripts": "6",
+  "averageExecutionTime": "124.67883333333327",
+  "averageScriptExecutionTime": "124.67883333333327"
+}, {
+  "canonicalDomain": "*.awin1.com",
+  "totalExecutionTime": "807.67000000000212",
+  "totalOccurrences": "6",
+  "totalScripts": "6",
+  "averageExecutionTime": "134.61166666666702",
+  "averageScriptExecutionTime": "134.61166666666702"
+}, {
+  "canonicalDomain": "*.expedia.com",
+  "totalExecutionTime": "0.019",
+  "totalOccurrences": "6",
+  "totalScripts": "6",
+  "averageExecutionTime": "0.0031666666666666666",
+  "averageScriptExecutionTime": "0.0031666666666666666"
+}, {
+  "canonicalDomain": "*.qeryz.com",
+  "totalExecutionTime": "631.0200000000001",
+  "totalOccurrences": "6",
+  "totalScripts": "8",
+  "averageExecutionTime": "105.17000000000002",
+  "averageScriptExecutionTime": "65.2838888888889"
+}, {
+  "canonicalDomain": "*.myunidays.com",
+  "totalExecutionTime": "980.79499999999064",
+  "totalOccurrences": "6",
+  "totalScripts": "6",
+  "averageExecutionTime": "163.46583333333174",
+  "averageScriptExecutionTime": "163.46583333333174"
+}, {
+  "canonicalDomain": "*.dpstatic.com",
+  "totalExecutionTime": "5054.4449999999979",
+  "totalOccurrences": "6",
+  "totalScripts": "13",
+  "averageExecutionTime": "842.40749999999957",
+  "averageScriptExecutionTime": "335.18513888888856"
+}, {
+  "canonicalDomain": "*.instaembedder.com",
+  "totalExecutionTime": "414.269",
+  "totalOccurrences": "6",
+  "totalScripts": "6",
+  "averageExecutionTime": "69.044833333333344",
+  "averageScriptExecutionTime": "69.044833333333344"
+}, {
+  "canonicalDomain": "*.mobify.com",
+  "totalExecutionTime": "1723.3599999999979",
+  "totalOccurrences": "6",
+  "totalScripts": "8",
+  "averageExecutionTime": "287.22666666666623",
+  "averageScriptExecutionTime": "165.5229999999998"
+}, {
+  "canonicalDomain": "*.samba.tv",
+  "totalExecutionTime": "278.366",
+  "totalOccurrences": "6",
+  "totalScripts": "6",
+  "averageExecutionTime": "46.394333333333336",
+  "averageScriptExecutionTime": "46.394333333333336"
+}, {
+  "canonicalDomain": "*.attraqt.com",
+  "totalExecutionTime": "504.79300000000217",
+  "totalOccurrences": "6",
+  "totalScripts": "6",
+  "averageExecutionTime": "84.132166666667032",
+  "averageScriptExecutionTime": "84.132166666667032"
+}, {
+  "canonicalDomain": "*.travelex.net",
+  "totalExecutionTime": "671.57100000000014",
+  "totalOccurrences": "6",
+  "totalScripts": "7",
+  "averageExecutionTime": "111.92850000000003",
+  "averageScriptExecutionTime": "111.23608333333335"
+}, {
+  "canonicalDomain": "*.s3ae.com",
+  "totalExecutionTime": "379.97100000000012",
+  "totalOccurrences": "6",
+  "totalScripts": "6",
+  "averageExecutionTime": "63.32850000000002",
+  "averageScriptExecutionTime": "63.32850000000002"
+}, {
+  "canonicalDomain": "*.fitanalytics.com",
+  "totalExecutionTime": "1308.3199999999981",
+  "totalOccurrences": "6",
+  "totalScripts": "6",
+  "averageExecutionTime": "218.05333333333303",
+  "averageScriptExecutionTime": "218.05333333333303"
+}, {
+  "canonicalDomain": "*.ostkcdn.com",
+  "totalExecutionTime": "12635.652999999917",
+  "totalOccurrences": "5",
+  "totalScripts": "37",
+  "averageExecutionTime": "2527.1305999999836",
+  "averageScriptExecutionTime": "356.96425666666494"
+}, {
+  "canonicalDomain": "*.romancart.com",
+  "totalExecutionTime": "311.137",
+  "totalOccurrences": "5",
+  "totalScripts": "7",
+  "averageExecutionTime": "62.2274",
+  "averageScriptExecutionTime": "38.913"
+}, {
+  "canonicalDomain": "*.cafonline.org",
+  "totalExecutionTime": "2271.9399999999882",
+  "totalOccurrences": "5",
+  "totalScripts": "10",
+  "averageExecutionTime": "454.38799999999765",
+  "averageScriptExecutionTime": "161.98243333333249"
+}, {
+  "canonicalDomain": "*.Quinstreet.com",
+  "totalExecutionTime": "207.43200000000002",
+  "totalOccurrences": "5",
+  "totalScripts": "5",
+  "averageExecutionTime": "41.4864",
+  "averageScriptExecutionTime": "41.4864"
+}, {
+  "canonicalDomain": "*.ecorebates.com",
+  "totalExecutionTime": "4624.4430000000066",
+  "totalOccurrences": "5",
+  "totalScripts": "5",
+  "averageExecutionTime": "924.88860000000147",
+  "averageScriptExecutionTime": "924.88860000000147"
+}, {
+  "canonicalDomain": "*.gscontxt.net",
+  "totalExecutionTime": "5984.8559999999643",
+  "totalOccurrences": "5",
+  "totalScripts": "5",
+  "averageExecutionTime": "1196.9711999999927",
+  "averageScriptExecutionTime": "1196.9711999999927"
+}, {
+  "canonicalDomain": "*.recommend.pro",
+  "totalExecutionTime": "374.87699999999995",
+  "totalOccurrences": "5",
+  "totalScripts": "5",
+  "averageExecutionTime": "74.975400000000008",
+  "averageScriptExecutionTime": "74.975400000000008"
+}, {
+  "canonicalDomain": "*.igodigital.com",
+  "totalExecutionTime": "78.105",
+  "totalOccurrences": "5",
+  "totalScripts": "5",
+  "averageExecutionTime": "15.620999999999999",
+  "averageScriptExecutionTime": "15.620999999999999"
+}, {
+  "canonicalDomain": "*.mozilla.org",
+  "totalExecutionTime": "3286.4229999999898",
+  "totalOccurrences": "5",
+  "totalScripts": "8",
+  "averageExecutionTime": "657.28459999999791",
+  "averageScriptExecutionTime": "355.11149999999867"
+}, {
+  "canonicalDomain": "*.smaato.net",
+  "totalExecutionTime": "190.27800000000002",
+  "totalOccurrences": "5",
+  "totalScripts": "5",
+  "averageExecutionTime": "38.0556",
+  "averageScriptExecutionTime": "38.0556"
+}, {
+  "canonicalDomain": "*.userzoom.com",
+  "totalExecutionTime": "1741.5399999999727",
+  "totalOccurrences": "5",
+  "totalScripts": "5",
+  "averageExecutionTime": "348.30799999999459",
+  "averageScriptExecutionTime": "348.30799999999459"
+}, {
+  "canonicalDomain": "*.iwantthatflight.com.au",
+  "totalExecutionTime": "2438.184999999994",
+  "totalOccurrences": "5",
+  "totalScripts": "6",
+  "averageExecutionTime": "487.63699999999886",
+  "averageScriptExecutionTime": "388.84749999999923"
+}, {
+  "canonicalDomain": "*.loggly.com",
+  "totalExecutionTime": "997.29299999999841",
+  "totalOccurrences": "5",
+  "totalScripts": "5",
+  "averageExecutionTime": "199.45859999999968",
+  "averageScriptExecutionTime": "199.45859999999968"
+}, {
+  "canonicalDomain": "*.surveygizmo.eu",
+  "totalExecutionTime": "240.154",
+  "totalOccurrences": "5",
+  "totalScripts": "5",
+  "averageExecutionTime": "48.0308",
+  "averageScriptExecutionTime": "48.0308"
+}, {
+  "canonicalDomain": "*.betrad.com",
+  "totalExecutionTime": "464.41400000000004",
+  "totalOccurrences": "5",
+  "totalScripts": "5",
+  "averageExecutionTime": "92.8828",
+  "averageScriptExecutionTime": "92.8828"
+}, {
+  "canonicalDomain": "*.getvero.com",
+  "totalExecutionTime": "331.79099999999988",
+  "totalOccurrences": "5",
+  "totalScripts": "5",
+  "averageExecutionTime": "66.358199999999982",
+  "averageScriptExecutionTime": "66.358199999999982"
+}, {
+  "canonicalDomain": "*.de.com",
+  "totalExecutionTime": "789.98899999999946",
+  "totalOccurrences": "5",
+  "totalScripts": "8",
+  "averageExecutionTime": "157.9977999999999",
+  "averageScriptExecutionTime": "96.963933333333287"
+}, {
+  "canonicalDomain": "*.performgroup.com",
+  "totalExecutionTime": "354.7580000000001",
+  "totalOccurrences": "5",
+  "totalScripts": "5",
+  "averageExecutionTime": "70.951600000000013",
+  "averageScriptExecutionTime": "70.951600000000013"
+}, {
+  "canonicalDomain": "*.vizzit.se",
+  "totalExecutionTime": "274.00500000000005",
+  "totalOccurrences": "5",
+  "totalScripts": "5",
+  "averageExecutionTime": "54.801",
+  "averageScriptExecutionTime": "54.801"
+}, {
+  "canonicalDomain": "*.sweettooth.io",
+  "totalExecutionTime": "289.791",
+  "totalOccurrences": "5",
+  "totalScripts": "5",
+  "averageExecutionTime": "57.958200000000005",
+  "averageScriptExecutionTime": "57.958200000000005"
+}, {
+  "canonicalDomain": "*.donreach.com",
+  "totalExecutionTime": "373.32700000000006",
+  "totalOccurrences": "5",
+  "totalScripts": "5",
+  "averageExecutionTime": "74.6654",
+  "averageScriptExecutionTime": "74.6654"
+}, {
+  "canonicalDomain": "*.provenpixel.com",
+  "totalExecutionTime": "251.04100000000005",
+  "totalOccurrences": "4",
+  "totalScripts": "4",
+  "averageExecutionTime": "62.760250000000013",
+  "averageScriptExecutionTime": "62.760250000000013"
+}, {
+  "canonicalDomain": "*.incisivemedia.com",
+  "totalExecutionTime": "653.70099999999979",
+  "totalOccurrences": "4",
+  "totalScripts": "5",
+  "averageExecutionTime": "163.42524999999995",
+  "averageScriptExecutionTime": "81.747499999999988"
+}, {
+  "canonicalDomain": "*.uplynk.com",
+  "totalExecutionTime": "570.89999999999861",
+  "totalOccurrences": "4",
+  "totalScripts": "4",
+  "averageExecutionTime": "142.72499999999968",
+  "averageScriptExecutionTime": "142.72499999999968"
+}, {
+  "canonicalDomain": "*.theguardian.com",
+  "totalExecutionTime": "3095.7699999999936",
+  "totalOccurrences": "4",
+  "totalScripts": "15",
+  "averageExecutionTime": "773.9424999999984",
+  "averageScriptExecutionTime": "263.8224374999993"
+}, {
+  "canonicalDomain": "*.streameye.net",
+  "totalExecutionTime": "1038.241",
+  "totalOccurrences": "4",
+  "totalScripts": "7",
+  "averageExecutionTime": "259.56025",
+  "averageScriptExecutionTime": "149.66341666666668"
+}, {
+  "canonicalDomain": "*.contentreserve.com",
+  "totalExecutionTime": "1937.6479999999988",
+  "totalOccurrences": "4",
+  "totalScripts": "8",
+  "averageExecutionTime": "484.41199999999964",
+  "averageScriptExecutionTime": "242.20599999999982"
+}, {
+  "canonicalDomain": "*.effiliation.com",
+  "totalExecutionTime": "286.4650000000002",
+  "totalOccurrences": "4",
+  "totalScripts": "4",
+  "averageExecutionTime": "71.616250000000036",
+  "averageScriptExecutionTime": "71.616250000000036"
+}, {
+  "canonicalDomain": "*.reachforce.com",
+  "totalExecutionTime": "250.63100000000003",
+  "totalOccurrences": "4",
+  "totalScripts": "4",
+  "averageExecutionTime": "62.657750000000007",
+  "averageScriptExecutionTime": "62.657750000000007"
+}, {
+  "canonicalDomain": "*.codigo.se",
+  "totalExecutionTime": "192.24900000000002",
+  "totalOccurrences": "4",
+  "totalScripts": "4",
+  "averageExecutionTime": "48.062250000000006",
+  "averageScriptExecutionTime": "48.062250000000006"
+}, {
+  "canonicalDomain": "*.editiondigital.com",
+  "totalExecutionTime": "243.75000000000009",
+  "totalOccurrences": "4",
+  "totalScripts": "4",
+  "averageExecutionTime": "60.937500000000014",
+  "averageScriptExecutionTime": "60.937500000000014"
+}, {
+  "canonicalDomain": "*.adx1.com",
+  "totalExecutionTime": "327.24800000000005",
+  "totalOccurrences": "4",
+  "totalScripts": "5",
+  "averageExecutionTime": "81.812000000000026",
+  "averageScriptExecutionTime": "67.664625000000015"
+}, {
+  "canonicalDomain": "*.maptive.com",
+  "totalExecutionTime": "13088.479999999941",
+  "totalOccurrences": "4",
+  "totalScripts": "16",
+  "averageExecutionTime": "3272.1199999999853",
+  "averageScriptExecutionTime": "818.02999999999633"
+}, {
+  "canonicalDomain": "*.apsisforms.com",
+  "totalExecutionTime": "464.63399999999996",
+  "totalOccurrences": "4",
+  "totalScripts": "4",
+  "averageExecutionTime": "116.1585",
+  "averageScriptExecutionTime": "116.1585"
+}, {
+  "canonicalDomain": "*.shopapps.in",
+  "totalExecutionTime": "478.72500000000019",
+  "totalOccurrences": "4",
+  "totalScripts": "4",
+  "averageExecutionTime": "119.68125000000003",
+  "averageScriptExecutionTime": "119.68125000000003"
+}, {
+  "canonicalDomain": "*.71n7.com",
+  "totalExecutionTime": "378.615",
+  "totalOccurrences": "4",
+  "totalScripts": "4",
+  "averageExecutionTime": "94.65375",
+  "averageScriptExecutionTime": "94.65375"
+}, {
+  "canonicalDomain": "*.playground.xyz",
+  "totalExecutionTime": "0.064",
+  "totalOccurrences": "4",
+  "totalScripts": "4",
+  "averageExecutionTime": "0.016",
+  "averageScriptExecutionTime": "0.016"
+}, {
+  "canonicalDomain": "*.geoplugin.com",
+  "totalExecutionTime": "847.85000000000014",
+  "totalOccurrences": "4",
+  "totalScripts": "4",
+  "averageExecutionTime": "211.96250000000003",
+  "averageScriptExecutionTime": "211.96250000000003"
+}, {
+  "canonicalDomain": "*.kinxcdn.com",
+  "totalExecutionTime": "1185.0269999999994",
+  "totalOccurrences": "4",
+  "totalScripts": "8",
+  "averageExecutionTime": "296.25674999999984",
+  "averageScriptExecutionTime": "148.12837499999992"
+}, {
+  "canonicalDomain": "*.ftjcfx.com",
+  "totalExecutionTime": "297.7819999999993",
+  "totalOccurrences": "3",
+  "totalScripts": "4",
+  "averageExecutionTime": "99.260666666666438",
+  "averageScriptExecutionTime": "50.113833333333218"
+}, {
+  "canonicalDomain": "*.webthinking.co.uk",
+  "totalExecutionTime": "274.49099999999993",
+  "totalOccurrences": "3",
+  "totalScripts": "3",
+  "averageExecutionTime": "91.496999999999986",
+  "averageScriptExecutionTime": "91.496999999999986"
+}, {
+  "canonicalDomain": "*.buzzfed.com",
+  "totalExecutionTime": "10107.709999999994",
+  "totalOccurrences": "3",
+  "totalScripts": "14",
+  "averageExecutionTime": "3369.236666666664",
+  "averageScriptExecutionTime": "532.9045793650788"
+}, {
+  "canonicalDomain": "*.amgdgt.com",
+  "totalExecutionTime": "237.22400000000005",
+  "totalOccurrences": "3",
+  "totalScripts": "4",
+  "averageExecutionTime": "79.074666666666673",
+  "averageScriptExecutionTime": "56.3035"
+}, {
+  "canonicalDomain": "*.sfr.fr",
+  "totalExecutionTime": "525.865",
+  "totalOccurrences": "3",
+  "totalScripts": "5",
+  "averageExecutionTime": "175.28833333333333",
+  "averageScriptExecutionTime": "108.52722222222224"
+}, {
+  "canonicalDomain": "*.ijento.com",
+  "totalExecutionTime": "208.895",
+  "totalOccurrences": "3",
+  "totalScripts": "3",
+  "averageExecutionTime": "69.631666666666675",
+  "averageScriptExecutionTime": "69.631666666666675"
+}, {
+  "canonicalDomain": "*.verisign.com",
+  "totalExecutionTime": "625.99200000000019",
+  "totalOccurrences": "3",
+  "totalScripts": "3",
+  "averageExecutionTime": "208.66400000000004",
+  "averageScriptExecutionTime": "208.66400000000004"
+}, {
+  "canonicalDomain": "*.smartzer.com",
+  "totalExecutionTime": "5097.6310000000358",
+  "totalOccurrences": "3",
+  "totalScripts": "4",
+  "averageExecutionTime": "1699.2103333333455",
+  "averageScriptExecutionTime": "886.44516666667278"
+}, {
+  "canonicalDomain": "*.rtm.com",
+  "totalExecutionTime": "148.357",
+  "totalOccurrences": "3",
+  "totalScripts": "3",
+  "averageExecutionTime": "49.452333333333335",
+  "averageScriptExecutionTime": "49.452333333333335"
+}, {
+  "canonicalDomain": "*.revjet.com",
+  "totalExecutionTime": "72.074000000000012",
+  "totalOccurrences": "3",
+  "totalScripts": "4",
+  "averageExecutionTime": "24.024666666666672",
+  "averageScriptExecutionTime": "18.838833333333341"
+}, {
+  "canonicalDomain": "*.murdoog.com",
+  "totalExecutionTime": "420.43299999999994",
+  "totalOccurrences": "3",
+  "totalScripts": "3",
+  "averageExecutionTime": "140.14433333333332",
+  "averageScriptExecutionTime": "140.14433333333332"
+}, {
+  "canonicalDomain": "*.bonzai.co",
+  "totalExecutionTime": "1055.4600000000007",
+  "totalOccurrences": "3",
+  "totalScripts": "8",
+  "averageExecutionTime": "351.82000000000028",
+  "averageScriptExecutionTime": "130.1411111111112"
+}, {
+  "canonicalDomain": "*.po.st",
+  "totalExecutionTime": "163.522",
+  "totalOccurrences": "3",
+  "totalScripts": "3",
+  "averageExecutionTime": "54.507333333333335",
+  "averageScriptExecutionTime": "54.507333333333335"
+}, {
+  "canonicalDomain": "*.searchforce.net",
+  "totalExecutionTime": "128.43400000000003",
+  "totalOccurrences": "3",
+  "totalScripts": "3",
+  "averageExecutionTime": "42.811333333333337",
+  "averageScriptExecutionTime": "42.811333333333337"
+}, {
+  "canonicalDomain": "*.googlecommerce.com",
+  "totalExecutionTime": "180.07199999999997",
+  "totalOccurrences": "3",
+  "totalScripts": "3",
+  "averageExecutionTime": "60.023999999999994",
+  "averageScriptExecutionTime": "60.023999999999994"
+}, {
+  "canonicalDomain": "*.jsonip.com",
+  "totalExecutionTime": "1546.5720000000001",
+  "totalOccurrences": "3",
+  "totalScripts": "3",
+  "averageExecutionTime": "515.52400000000011",
+  "averageScriptExecutionTime": "515.52400000000011"
+}, {
+  "canonicalDomain": "*.copperegg.com",
+  "totalExecutionTime": "95.769",
+  "totalOccurrences": "3",
+  "totalScripts": "3",
+  "averageExecutionTime": "31.923",
+  "averageScriptExecutionTime": "31.923"
+}, {
+  "canonicalDomain": "*.go2cloud.org",
+  "totalExecutionTime": "0.038",
+  "totalOccurrences": "3",
+  "totalScripts": "3",
+  "averageExecutionTime": "0.012666666666666666",
+  "averageScriptExecutionTime": "0.012666666666666666"
+}, {
+  "canonicalDomain": "*.visscore.com",
+  "totalExecutionTime": "145.35000000000002",
+  "totalOccurrences": "3",
+  "totalScripts": "3",
+  "averageExecutionTime": "48.45",
+  "averageScriptExecutionTime": "48.45"
+}, {
+  "canonicalDomain": "*.mybuys.com",
+  "totalExecutionTime": "216.38600000000008",
+  "totalOccurrences": "3",
+  "totalScripts": "3",
+  "averageExecutionTime": "72.1286666666667",
+  "averageScriptExecutionTime": "72.1286666666667"
+}, {
+  "canonicalDomain": "*.xlcdn.com",
+  "totalExecutionTime": "4298.3569999999927",
+  "totalOccurrences": "3",
+  "totalScripts": "12",
+  "averageExecutionTime": "1432.7856666666642",
+  "averageScriptExecutionTime": "358.19641666666604"
+}, {
+  "canonicalDomain": "*.agilitycms.com",
+  "totalExecutionTime": "2976.0069999999923",
+  "totalOccurrences": "3",
+  "totalScripts": "4",
+  "averageExecutionTime": "992.00233333333085",
+  "averageScriptExecutionTime": "760.8464999999976"
+}, {
+  "canonicalDomain": "*.insightexpressai.com",
+  "totalExecutionTime": "0.05",
+  "totalOccurrences": "3",
+  "totalScripts": "3",
+  "averageExecutionTime": "0.016666666666666666",
+  "averageScriptExecutionTime": "0.016666666666666666"
+}, {
+  "canonicalDomain": "*.adwise.bg",
+  "totalExecutionTime": "276.67199999999991",
+  "totalOccurrences": "3",
+  "totalScripts": "6",
+  "averageExecutionTime": "92.223999999999961",
+  "averageScriptExecutionTime": "34.022749999999988"
+}, {
+  "canonicalDomain": "*.yieldlab.net",
+  "totalExecutionTime": "13.712",
+  "totalOccurrences": "3",
+  "totalScripts": "3",
+  "averageExecutionTime": "4.5706666666666669",
+  "averageScriptExecutionTime": "4.5706666666666669"
+}, {
+  "canonicalDomain": "*.nflxext.com",
+  "totalExecutionTime": "2402.9749999999931",
+  "totalOccurrences": "3",
+  "totalScripts": "6",
+  "averageExecutionTime": "800.9916666666644",
+  "averageScriptExecutionTime": "400.4958333333322"
+}, {
+  "canonicalDomain": "*.cfjump.com",
+  "totalExecutionTime": "252.98300000000003",
+  "totalOccurrences": "3",
+  "totalScripts": "3",
+  "averageExecutionTime": "84.327666666666673",
+  "averageScriptExecutionTime": "84.327666666666673"
+}, {
+  "canonicalDomain": "*.getsocial.io",
+  "totalExecutionTime": "424.37899999999991",
+  "totalOccurrences": "2",
+  "totalScripts": "2",
+  "averageExecutionTime": "212.18949999999995",
+  "averageScriptExecutionTime": "212.18949999999995"
+}, {
+  "canonicalDomain": "*.flexshopper.com",
+  "totalExecutionTime": "144.219",
+  "totalOccurrences": "2",
+  "totalScripts": "2",
+  "averageExecutionTime": "72.1095",
+  "averageScriptExecutionTime": "72.1095"
+}, {
+  "canonicalDomain": "*.letsencrypt.org",
+  "totalExecutionTime": "87.112000000000066",
+  "totalOccurrences": "2",
+  "totalScripts": "2",
+  "averageExecutionTime": "43.556000000000033",
+  "averageScriptExecutionTime": "43.556000000000033"
+}, {
+  "canonicalDomain": "*.avg.com",
+  "totalExecutionTime": "2127.3329999999978",
+  "totalOccurrences": "2",
+  "totalScripts": "8",
+  "averageExecutionTime": "1063.6664999999989",
+  "averageScriptExecutionTime": "198.88092857142846"
+}, {
+  "canonicalDomain": "*.dotmailer-surveys.com",
+  "totalExecutionTime": "43.820999999999991",
+  "totalOccurrences": "2",
+  "totalScripts": "3",
+  "averageExecutionTime": "21.910499999999995",
+  "averageScriptExecutionTime": "11.579999999999997"
+}, {
+  "canonicalDomain": "*.reachmee.com",
+  "totalExecutionTime": "800.607999999998",
+  "totalOccurrences": "2",
+  "totalScripts": "5",
+  "averageExecutionTime": "400.303999999999",
+  "averageScriptExecutionTime": "197.25574999999952"
+}, {
+  "canonicalDomain": "*.visualstudio.com",
+  "totalExecutionTime": "2766.8639999999805",
+  "totalOccurrences": "2",
+  "totalScripts": "5",
+  "averageExecutionTime": "1383.4319999999902",
+  "averageScriptExecutionTime": "639.47658333332868"
+}, {
+  "canonicalDomain": "*.opinionbar.com",
+  "totalExecutionTime": "142.447",
+  "totalOccurrences": "2",
+  "totalScripts": "2",
+  "averageExecutionTime": "71.2235",
+  "averageScriptExecutionTime": "71.2235"
+}, {
+  "canonicalDomain": "*.sekindo.com",
+  "totalExecutionTime": "186.21100000000004",
+  "totalOccurrences": "2",
+  "totalScripts": "2",
+  "averageExecutionTime": "93.105500000000021",
+  "averageScriptExecutionTime": "93.105500000000021"
+}, {
+  "canonicalDomain": "*.adzip.co",
+  "totalExecutionTime": "395.15499999999929",
+  "totalOccurrences": "2",
+  "totalScripts": "2",
+  "averageExecutionTime": "197.57749999999965",
+  "averageScriptExecutionTime": "197.57749999999965"
+}, {
+  "canonicalDomain": "*.addthisevent.com",
+  "totalExecutionTime": "119.84000000000003",
+  "totalOccurrences": "2",
+  "totalScripts": "2",
+  "averageExecutionTime": "59.920000000000016",
+  "averageScriptExecutionTime": "59.920000000000016"
+}, {
+  "canonicalDomain": "*.poweringnews.com",
+  "totalExecutionTime": "76.995999999999981",
+  "totalOccurrences": "2",
+  "totalScripts": "2",
+  "averageExecutionTime": "38.49799999999999",
+  "averageScriptExecutionTime": "38.49799999999999"
+}, {
+  "canonicalDomain": "*.keyade.com",
+  "totalExecutionTime": "97.637",
+  "totalOccurrences": "2",
+  "totalScripts": "2",
+  "averageExecutionTime": "48.8185",
+  "averageScriptExecutionTime": "48.8185"
+}, {
+  "canonicalDomain": "*.vdna-assets.com",
+  "totalExecutionTime": "1422.0160000000017",
+  "totalOccurrences": "2",
+  "totalScripts": "2",
+  "averageExecutionTime": "711.00800000000083",
+  "averageScriptExecutionTime": "711.00800000000083"
+}, {
+  "canonicalDomain": "*.layer0.co",
+  "totalExecutionTime": "213.20700000000005",
+  "totalOccurrences": "2",
+  "totalScripts": "2",
+  "averageExecutionTime": "106.60350000000003",
+  "averageScriptExecutionTime": "106.60350000000003"
+}, {
+  "canonicalDomain": "*.marketgid.com",
+  "totalExecutionTime": "1.0150000000000001",
+  "totalOccurrences": "2",
+  "totalScripts": "2",
+  "averageExecutionTime": "0.50750000000000006",
+  "averageScriptExecutionTime": "0.50750000000000006"
+}, {
+  "canonicalDomain": "*.zergnet.com",
+  "totalExecutionTime": "81.777000000000015",
+  "totalOccurrences": "2",
+  "totalScripts": "2",
+  "averageExecutionTime": "40.888500000000008",
+  "averageScriptExecutionTime": "40.888500000000008"
+}, {
+  "canonicalDomain": "*.aheadworks.com",
+  "totalExecutionTime": "271.92599999999987",
+  "totalOccurrences": "2",
+  "totalScripts": "2",
+  "averageExecutionTime": "135.96299999999994",
+  "averageScriptExecutionTime": "135.96299999999994"
+}, {
+  "canonicalDomain": "*.shopkeepertools.com",
+  "totalExecutionTime": "109.13",
+  "totalOccurrences": "2",
+  "totalScripts": "2",
+  "averageExecutionTime": "54.565",
+  "averageScriptExecutionTime": "54.565"
+}, {
+  "canonicalDomain": "*.mfadsrvr.com",
+  "totalExecutionTime": "0.057",
+  "totalOccurrences": "2",
+  "totalScripts": "2",
+  "averageExecutionTime": "0.0285",
+  "averageScriptExecutionTime": "0.0285"
+}, {
+  "canonicalDomain": "*.travelzoo.com",
+  "totalExecutionTime": "3346.8639999999928",
+  "totalOccurrences": "2",
+  "totalScripts": "6",
+  "averageExecutionTime": "1673.4319999999964",
+  "averageScriptExecutionTime": "557.8106666666655"
+}, {
+  "canonicalDomain": "*.admedia.com",
+  "totalExecutionTime": "146.769",
+  "totalOccurrences": "2",
+  "totalScripts": "2",
+  "averageExecutionTime": "73.3845",
+  "averageScriptExecutionTime": "73.3845"
+}, {
+  "canonicalDomain": "*.adschoom.com",
+  "totalExecutionTime": "51.97699999999999",
+  "totalOccurrences": "2",
+  "totalScripts": "2",
+  "averageExecutionTime": "25.988499999999995",
+  "averageScriptExecutionTime": "25.988499999999995"
+}, {
+  "canonicalDomain": "*.emap.com",
+  "totalExecutionTime": "54.898000000000017",
+  "totalOccurrences": "2",
+  "totalScripts": "2",
+  "averageExecutionTime": "27.449000000000009",
+  "averageScriptExecutionTime": "27.449000000000009"
+}, {
+  "canonicalDomain": "*.zoover.nl",
+  "totalExecutionTime": "6248.4549999999463",
+  "totalOccurrences": "2",
+  "totalScripts": "14",
+  "averageExecutionTime": "3124.2274999999731",
+  "averageScriptExecutionTime": "435.26333333332957"
+}, {
+  "canonicalDomain": "*.wsj.net",
+  "totalExecutionTime": "292.676",
+  "totalOccurrences": "2",
+  "totalScripts": "2",
+  "averageExecutionTime": "146.338",
+  "averageScriptExecutionTime": "146.338"
+}, {
+  "canonicalDomain": "*.myfonts.net",
+  "totalExecutionTime": "15.167000000000002",
+  "totalOccurrences": "2",
+  "totalScripts": "2",
+  "averageExecutionTime": "7.5835000000000008",
+  "averageScriptExecutionTime": "7.5835000000000008"
+}, {
+  "canonicalDomain": "*.bankrate.com",
+  "totalExecutionTime": "1876.2129999999966",
+  "totalOccurrences": "2",
+  "totalScripts": "8",
+  "averageExecutionTime": "938.10649999999828",
+  "averageScriptExecutionTime": "147.11107142857119"
+}, {
+  "canonicalDomain": "*.launchdarkly.com",
+  "totalExecutionTime": "94.804000000000059",
+  "totalOccurrences": "2",
+  "totalScripts": "2",
+  "averageExecutionTime": "47.402000000000029",
+  "averageScriptExecutionTime": "47.402000000000029"
+}, {
+  "canonicalDomain": "*.smh.com.au",
+  "totalExecutionTime": "5755.5550000000758",
+  "totalOccurrences": "2",
+  "totalScripts": "7",
+  "averageExecutionTime": "2877.7775000000379",
+  "averageScriptExecutionTime": "479.62958333333972"
+}, {
+  "canonicalDomain": "di6367dava8ow.cloudfront.net",
+  "totalExecutionTime": "223.82000000000011",
+  "totalOccurrences": "2",
+  "totalScripts": "2",
+  "averageExecutionTime": "111.91000000000005",
+  "averageScriptExecutionTime": "111.91000000000005"
+}, {
+  "canonicalDomain": "*.sectigo.com",
+  "totalExecutionTime": "1039.9100000000005",
+  "totalOccurrences": "2",
+  "totalScripts": "4",
+  "averageExecutionTime": "519.95500000000027",
+  "averageScriptExecutionTime": "179.60100000000011"
+}, {
+  "canonicalDomain": "*.trustwave.com",
+  "totalExecutionTime": "19.470000000000006",
+  "totalOccurrences": "2",
+  "totalScripts": "2",
+  "averageExecutionTime": "9.735000000000003",
+  "averageScriptExecutionTime": "9.735000000000003"
+}, {
+  "canonicalDomain": "*.eway.com.au",
+  "totalExecutionTime": "25232.061000000293",
+  "totalOccurrences": "1",
+  "totalScripts": "5",
+  "averageExecutionTime": "25232.061000000293",
+  "averageScriptExecutionTime": "5046.41220000006"
+}, {
+  "canonicalDomain": "*.gridsumdissector.com",
+  "totalExecutionTime": "1158.4789999999864",
+  "totalOccurrences": "1",
+  "totalScripts": "1",
+  "averageExecutionTime": "1158.4789999999864",
+  "averageScriptExecutionTime": "1158.4789999999864"
+}, {
+  "canonicalDomain": "*.actonsoftware.com",
+  "totalExecutionTime": "42.425000000000004",
+  "totalOccurrences": "1",
+  "totalScripts": "1",
+  "averageExecutionTime": "42.425000000000004",
+  "averageScriptExecutionTime": "42.425000000000004"
+}, {
+  "canonicalDomain": "*.macromill.com",
+  "totalExecutionTime": "131.54400000000012",
+  "totalOccurrences": "1",
+  "totalScripts": "1",
+  "averageExecutionTime": "131.54400000000012",
+  "averageScriptExecutionTime": "131.54400000000012"
+}, {
+  "canonicalDomain": "*.performfeeds.com",
+  "totalExecutionTime": "205.779",
+  "totalOccurrences": "1",
+  "totalScripts": "2",
+  "averageExecutionTime": "205.779",
+  "averageScriptExecutionTime": "102.8895"
+}, {
+  "canonicalDomain": "*.momondo.dk",
+  "totalExecutionTime": "98.960999999999984",
+  "totalOccurrences": "1",
+  "totalScripts": "1",
+  "averageExecutionTime": "98.960999999999984",
+  "averageScriptExecutionTime": "98.960999999999984"
+}, {
+  "canonicalDomain": "*.merchantequip.com",
+  "totalExecutionTime": "220.20899999999972",
+  "totalOccurrences": "1",
+  "totalScripts": "2",
+  "averageExecutionTime": "220.20899999999972",
+  "averageScriptExecutionTime": "110.10449999999986"
+}, {
+  "canonicalDomain": "*.photorank.me",
+  "totalExecutionTime": "39.896000000000008",
+  "totalOccurrences": "1",
+  "totalScripts": "1",
+  "averageExecutionTime": "39.896000000000008",
+  "averageScriptExecutionTime": "39.896000000000008"
+}, {
+  "canonicalDomain": "*.mediawallahscript.com",
+  "totalExecutionTime": "500.08199999999846",
+  "totalOccurrences": "1",
+  "totalScripts": "1",
+  "averageExecutionTime": "500.08199999999846",
+  "averageScriptExecutionTime": "500.08199999999846"
+}, {
+  "canonicalDomain": "*.t.co",
+  "totalExecutionTime": "4.67",
+  "totalOccurrences": "1",
+  "totalScripts": "1",
+  "averageExecutionTime": "4.67",
+  "averageScriptExecutionTime": "4.67"
+}, {
+  "canonicalDomain": "*.dummyimage.com",
+  "totalExecutionTime": "820.96399999999869",
+  "totalOccurrences": "1",
+  "totalScripts": "6",
+  "averageExecutionTime": "820.96399999999869",
+  "averageScriptExecutionTime": "136.82733333333309"
+}, {
+  "canonicalDomain": "*.thawte.com",
+  "totalExecutionTime": "418.91700000000037",
+  "totalOccurrences": "1",
+  "totalScripts": "4",
+  "averageExecutionTime": "418.91700000000037",
+  "averageScriptExecutionTime": "104.72925000000009"
+}, {
+  "canonicalDomain": "*.audiencemanager.de",
+  "totalExecutionTime": "114.11",
+  "totalOccurrences": "1",
+  "totalScripts": "1",
+  "averageExecutionTime": "114.11",
+  "averageScriptExecutionTime": "114.11"
+}, {
+  "canonicalDomain": "*.ethn.io",
+  "totalExecutionTime": "133.96999999999991",
+  "totalOccurrences": "1",
+  "totalScripts": "1",
+  "averageExecutionTime": "133.96999999999991",
+  "averageScriptExecutionTime": "133.96999999999991"
+}, {
+  "canonicalDomain": "*.flaticons.net",
+  "totalExecutionTime": "5717.5429999998805",
+  "totalOccurrences": "1",
+  "totalScripts": "3",
+  "averageExecutionTime": "5717.5429999998805",
+  "averageScriptExecutionTime": "1905.8476666666272"
+}, {
+  "canonicalDomain": "*.edigitalresearch.com",
+  "totalExecutionTime": "96.802000000000049",
+  "totalOccurrences": "1",
+  "totalScripts": "1",
+  "averageExecutionTime": "96.802000000000049",
+  "averageScriptExecutionTime": "96.802000000000049"
+}, {
+  "canonicalDomain": "d1lxhc4jvstzrp.cloudfront.net",
+  "totalExecutionTime": "4.5089999999999995",
+  "totalOccurrences": "1",
+  "totalScripts": "1",
+  "averageExecutionTime": "4.5089999999999995",
+  "averageScriptExecutionTime": "4.5089999999999995"
+}, {
+  "canonicalDomain": "*.answcdn.com",
+  "totalExecutionTime": "568.5729999999985",
+  "totalOccurrences": "1",
+  "totalScripts": "2",
+  "averageExecutionTime": "568.5729999999985",
+  "averageScriptExecutionTime": "284.28649999999925"
+}, {
+  "canonicalDomain": "*.connexity.net",
+  "totalExecutionTime": "257.445",
+  "totalOccurrences": "1",
+  "totalScripts": "1",
+  "averageExecutionTime": "257.445",
+  "averageScriptExecutionTime": "257.445"
+}, {
+  "canonicalDomain": "*.rapidssl.com",
+  "totalExecutionTime": "539.89700000000073",
+  "totalOccurrences": "1",
+  "totalScripts": "5",
+  "averageExecutionTime": "539.89700000000073",
+  "averageScriptExecutionTime": "107.97940000000017"
+}, {
+  "canonicalDomain": "*.scribblelive.com",
+  "totalExecutionTime": "0.69400000000000006",
+  "totalOccurrences": "1",
+  "totalScripts": "1",
+  "averageExecutionTime": "0.69400000000000006",
+  "averageScriptExecutionTime": "0.69400000000000006"
+}, {
+  "canonicalDomain": "*.withcubed.com",
+  "totalExecutionTime": "54.361",
+  "totalOccurrences": "1",
+  "totalScripts": "1",
+  "averageExecutionTime": "54.361",
+  "averageScriptExecutionTime": "54.361"
+}, {
+  "canonicalDomain": "*.revv.co",
+  "totalExecutionTime": "2298.4279999999972",
+  "totalOccurrences": "1",
+  "totalScripts": "5",
+  "averageExecutionTime": "2298.4279999999972",
+  "averageScriptExecutionTime": "459.68559999999945"
+}, {
+  "canonicalDomain": "*.aimediagroup.com",
+  "totalExecutionTime": "76.89700000000002",
+  "totalOccurrences": "1",
+  "totalScripts": "2",
+  "averageExecutionTime": "76.89700000000002",
+  "averageScriptExecutionTime": "38.44850000000001"
+}, {
+  "canonicalDomain": "*.assets-cdk.com",
+  "totalExecutionTime": "36.806000000000004",
+  "totalOccurrences": "1",
+  "totalScripts": "1",
+  "averageExecutionTime": "36.806000000000004",
+  "averageScriptExecutionTime": "36.806000000000004"
+}, {
+  "canonicalDomain": "*.rss2json.com",
+  "totalExecutionTime": "81.618000000000009",
+  "totalOccurrences": "1",
+  "totalScripts": "1",
+  "averageExecutionTime": "81.618000000000009",
+  "averageScriptExecutionTime": "81.618000000000009"
+}, {
+  "canonicalDomain": "*.netsolssl.com",
+  "totalExecutionTime": "1581.2279999999969",
+  "totalOccurrences": "1",
+  "totalScripts": "5",
+  "averageExecutionTime": "1581.2279999999969",
+  "averageScriptExecutionTime": "316.2455999999994"
+}, {
+  "canonicalDomain": "*.delicious.com",
+  "totalExecutionTime": "59.335000000000022",
+  "totalOccurrences": "1",
+  "totalScripts": "1",
+  "averageExecutionTime": "59.335000000000022",
+  "averageScriptExecutionTime": "59.335000000000022"
+}, {
+  "canonicalDomain": "*.nochex.com",
+  "totalExecutionTime": "1463.9299999999957",
+  "totalOccurrences": "1",
+  "totalScripts": "7",
+  "averageExecutionTime": "1463.9299999999957",
+  "averageScriptExecutionTime": "209.13285714285658"
+}, {
+  "canonicalDomain": "*.checkfront.com",
+  "totalExecutionTime": "48.063000000000017",
+  "totalOccurrences": "1",
+  "totalScripts": "1",
+  "averageExecutionTime": "48.063000000000017",
+  "averageScriptExecutionTime": "48.063000000000017"
+}, {
+  "canonicalDomain": "*.dyntrk.com",
+  "totalExecutionTime": "24.66",
+  "totalOccurrences": "1",
+  "totalScripts": "1",
+  "averageExecutionTime": "24.66",
+  "averageScriptExecutionTime": "24.66"
+}, {
+  "canonicalDomain": "*.myspace.com",
+  "totalExecutionTime": "15.278000000000002",
+  "totalOccurrences": "1",
+  "totalScripts": "1",
+  "averageExecutionTime": "15.278000000000002",
+  "averageScriptExecutionTime": "15.278000000000002"
+}, {
+  "canonicalDomain": "*.govmetric.com",
+  "totalExecutionTime": "44.693000000000019",
+  "totalOccurrences": "1",
+  "totalScripts": "1",
+  "averageExecutionTime": "44.693000000000019",
+  "averageScriptExecutionTime": "44.693000000000019"
+}, {
+  "canonicalDomain": "*.yadro.ru",
+  "totalExecutionTime": "0.026000000000000002",
+  "totalOccurrences": "1",
+  "totalScripts": "1",
+  "averageExecutionTime": "0.026000000000000002",
+  "averageScriptExecutionTime": "0.026000000000000002"
+}, {
+  "canonicalDomain": "*.pki.goog",
+  "totalExecutionTime": "116.53000000000007",
+  "totalOccurrences": "1",
+  "totalScripts": "2",
+  "averageExecutionTime": "116.53000000000007",
+  "averageScriptExecutionTime": "58.265000000000029"
+}, {
+  "canonicalDomain": "*.btncdn.com",
+  "totalExecutionTime": "28.323999999999998",
+  "totalOccurrences": "1",
+  "totalScripts": "1",
+  "averageExecutionTime": "28.323999999999998",
+  "averageScriptExecutionTime": "28.323999999999998"
+}, {
+  "canonicalDomain": "*.clickadu.com",
+  "totalExecutionTime": "1208.7859999999996",
+  "totalOccurrences": "1",
+  "totalScripts": "3",
+  "averageExecutionTime": "1208.7859999999996",
+  "averageScriptExecutionTime": "402.92866666666652"
+}, {
+  "canonicalDomain": "*.feedoptimise.com",
+  "totalExecutionTime": "60.846000000000004",
+  "totalOccurrences": "1",
+  "totalScripts": "1",
+  "averageExecutionTime": "60.846000000000004",
+  "averageScriptExecutionTime": "60.846000000000004"
+}, {
+  "canonicalDomain": "*.dowjones.com",
+  "totalExecutionTime": "217.45599999999993",
+  "totalOccurrences": "1",
+  "totalScripts": "1",
+  "averageExecutionTime": "217.45599999999993",
+  "averageScriptExecutionTime": "217.45599999999993"
+}, {
+  "canonicalDomain": "*.euroland.com",
+  "totalExecutionTime": "0.029",
+  "totalOccurrences": "1",
+  "totalScripts": "1",
+  "averageExecutionTime": "0.029",
+  "averageScriptExecutionTime": "0.029"
+}, {
+  "canonicalDomain": "*.clikpic.com",
+  "totalExecutionTime": "75.399000000000058",
+  "totalOccurrences": "1",
+  "totalScripts": "2",
+  "averageExecutionTime": "75.399000000000058",
+  "averageScriptExecutionTime": "37.699500000000029"
+}, {
+  "canonicalDomain": "*.looper.com",
+  "totalExecutionTime": "31.742999999999995",
+  "totalOccurrences": "1",
+  "totalScripts": "1",
+  "averageExecutionTime": "31.742999999999995",
+  "averageScriptExecutionTime": "31.742999999999995"
+}, {
+  "canonicalDomain": "*.iljmp.com",
+  "totalExecutionTime": "46.353",
+  "totalOccurrences": "1",
+  "totalScripts": "1",
+  "averageExecutionTime": "46.353",
+  "averageScriptExecutionTime": "46.353"
+}, {
+  "canonicalDomain": "*.marketwatch.com",
+  "totalExecutionTime": "2768.2679999999809",
+  "totalOccurrences": "1",
+  "totalScripts": "2",
+  "averageExecutionTime": "2768.2679999999809",
+  "averageScriptExecutionTime": "1384.1339999999905"
+}, {
+  "canonicalDomain": "*.bet365affiliates.com",
+  "totalExecutionTime": "1.7469999999999994",
+  "totalOccurrences": "1",
+  "totalScripts": "1",
+  "averageExecutionTime": "1.7469999999999994",
+  "averageScriptExecutionTime": "1.7469999999999994"
+}, {
+  "canonicalDomain": "*.godatafeed.com",
+  "totalExecutionTime": "0.068",
+  "totalOccurrences": "1",
+  "totalScripts": "1",
+  "averageExecutionTime": "0.068",
+  "averageScriptExecutionTime": "0.068"
+}, {
+  "canonicalDomain": "*.hootsuite.com",
+  "totalExecutionTime": "17549.922000000166",
+  "totalOccurrences": "1",
+  "totalScripts": "7",
+  "averageExecutionTime": "17549.922000000166",
+  "averageScriptExecutionTime": "2507.1317142857388"
+}, {
+  "canonicalDomain": "*.empathybroker.com",
+  "totalExecutionTime": "641.9759999999909",
+  "totalOccurrences": "1",
+  "totalScripts": "1",
+  "averageExecutionTime": "641.9759999999909",
+  "averageScriptExecutionTime": "641.9759999999909"
+}, {
+  "canonicalDomain": "*.expedia.co.uk",
+  "totalExecutionTime": "0.0",
+  "totalOccurrences": "1",
+  "totalScripts": "1",
+  "averageExecutionTime": "0.0",
+  "averageScriptExecutionTime": "0.0"
+}, {
+  "canonicalDomain": "*.mcafeesecure.com",
+  "totalExecutionTime": "0.051",
+  "totalOccurrences": "1",
+  "totalScripts": "1",
+  "averageExecutionTime": "0.051",
+  "averageScriptExecutionTime": "0.051"
+}, {
+  "canonicalDomain": "*.veoxa.com",
+  "totalExecutionTime": "45.70000000000001",
+  "totalOccurrences": "1",
+  "totalScripts": "1",
+  "averageExecutionTime": "45.70000000000001",
+  "averageScriptExecutionTime": "45.70000000000001"
+}, {
+  "canonicalDomain": "*.adtechus.com",
+  "totalExecutionTime": "70.876000000000047",
+  "totalOccurrences": "1",
+  "totalScripts": "1",
+  "averageExecutionTime": "70.876000000000047",
+  "averageScriptExecutionTime": "70.876000000000047"
+}, {
+  "canonicalDomain": "*.georiot.com",
+  "totalExecutionTime": "25.903999999999989",
+  "totalOccurrences": "1",
+  "totalScripts": "1",
+  "averageExecutionTime": "25.903999999999989",
+  "averageScriptExecutionTime": "25.903999999999989"
+}, {
+  "canonicalDomain": "*.securitymetrics.com",
+  "totalExecutionTime": "553.1700000000003",
+  "totalOccurrences": "1",
+  "totalScripts": "3",
+  "averageExecutionTime": "553.1700000000003",
+  "averageScriptExecutionTime": "184.39000000000007"
+}, {
+  "canonicalDomain": "*.axs.com",
+  "totalExecutionTime": "3157.9449999999811",
+  "totalOccurrences": "1",
+  "totalScripts": "4",
+  "averageExecutionTime": "3157.9449999999811",
+  "averageScriptExecutionTime": "789.48624999999527"
+}, {
+  "canonicalDomain": "*.webcollage.net",
+  "totalExecutionTime": "7.0619999999999985",
+  "totalOccurrences": "1",
+  "totalScripts": "1",
+  "averageExecutionTime": "7.0619999999999985",
+  "averageScriptExecutionTime": "7.0619999999999985"
+}, {
+  "canonicalDomain": "*.rdcdn.com",
+  "totalExecutionTime": "0.018000000000000002",
+  "totalOccurrences": "1",
+  "totalScripts": "1",
+  "averageExecutionTime": "0.018000000000000002",
+  "averageScriptExecutionTime": "0.018000000000000002"
+}, {
+  "canonicalDomain": "*.adestra.com",
+  "totalExecutionTime": "4.847999999999999",
+  "totalOccurrences": "1",
+  "totalScripts": "1",
+  "averageExecutionTime": "4.847999999999999",
+  "averageScriptExecutionTime": "4.847999999999999"
+}]

--- a/data/entities.js
+++ b/data/entities.js
@@ -1708,8 +1708,10 @@ module.exports = [
   },
   {
     name: 'AB Tasty',
+    homepage: 'https://www.abtasty.com/',
     category: 'analytics',
     domains: ['*.abtasty.com', 'd1447tq2m68ekg.cloudfront.net'],
+    examples: ['try.abtasty.com']
   },
   {
     name: 'ABA RESEARCH',
@@ -5842,8 +5844,10 @@ module.exports = [
   },
   {
     name: 'Kameleoon',
+    homepage: 'https://www.kameleoon.com/',
     category: 'analytics',
-    domains: ['*.kameleoon.com', '*.kameleoon.eu'],
+    domains: ['*.kameleoon.com', '*.kameleoon.eu', '*.kameleoon.io'],
+    examples: ['data.kameleoon.io', 'kdm3fpv6il.kameleoon.eu'],
   },
   {
     name: 'Kampyle',

--- a/sql/all-observed-domains-query.sql
+++ b/sql/all-observed-domains-query.sql
@@ -14,7 +14,5 @@ FROM (
 )
 GROUP BY
   domain
-HAVING
-  totalOccurrences >= 50
 ORDER BY
   totalOccurrences DESC


### PR DESCRIPTION
This PR is here to expose and suggest a fix to inaccurate computed data when third party runs a script from dynamic subdomain. 

As an example we took `Kameleoon` third party analytic script. We can see that before our change (and on [2024-06 data](https://github.com/patrickhulce/third-party-web/blob/bb8670dd54fcbf34daeace00c452f39031f854df/data/2024-06-01-entity-scripting.json)), it has an `averageExecutionTime` of [`~245ms`](https://github.com/patrickhulce/third-party-web/blob/bb8670dd54fcbf34daeace00c452f39031f854df/data/2024-06-01-entity-scripting.json#L2862) on a total of [`988` websites](https://github.com/patrickhulce/third-party-web/blob/bb8670dd54fcbf34daeace00c452f39031f854df/data/2024-06-01-entity-scripting.json#L2860) which is pretty good but not ranked on README because of its low occurences (below 1000).

What's wrong here is that this third party uses a dynamic subdomain to serve its main script on websites (e.g [`9e9soula8o.kameleoon.eu`](https://github.com/patrickhulce/third-party-web/blob/bb8670dd54fcbf34daeace00c452f39031f854df/data/2024-06-01-observed-domains.json)). Some of these subdomain scripts are kept in final result but analyzing raw `observed-domains` we found a lot that are ignored (~450). 

So we've decided to [remove this filter of `50` occurrences](https://github.com/Kporal/third-party-web/pull/3/files#diff-5d3cae766ffdf887a4057e2fccbfadb8fb3cccc68df89e19d96d91d80daff089L17-L18) of an observed-domain to be included in `averageExecutionTime` computation.

After updating data without this filter, we found that third party using dynamic subdomains are less favored in ranking because of much more accurate `averageExecutionTime` closer to its concurrents. As an example, for Kameleoon, we found that its `totalOccurences` grows-up to [`1438`](https://github.com/Kporal/third-party-web/pull/3/files#diff-2af9ab60a9c2f66c4873f6af2d2b07093e03faa8c6d96b24d7fb33acc634209bR2587)(+450) meaning it now appears in README ranking (n°62) but with a much more accurate `averageExecutionTime` value of `~599ms` (+354ms). 

As a concurrent comparison we can list:

| Product | `averageExecutionTime` With filter | `averageExecutionTime` Without filter | Diff |
| ------------- | ------------- | ------------- | ------------- |
| Kameleoon  |  [245ms](https://github.com/patrickhulce/third-party-web/pull/222/files#diff-2af9ab60a9c2f66c4873f6af2d2b07093e03faa8c6d96b24d7fb33acc634209bR2862) |  600ms | +355ms
| Optimizely  | [857ms](https://github.com/patrickhulce/third-party-web/pull/222/files#diff-2af9ab60a9c2f66c4873f6af2d2b07093e03faa8c6d96b24d7fb33acc634209bR1035)  |  861ms | +4ms
| VWO  | [638ms](https://github.com/patrickhulce/third-party-web/pull/222/files#diff-2af9ab60a9c2f66c4873f6af2d2b07093e03faa8c6d96b24d7fb33acc634209bR1413)  |  638ms | +0ms
| ABTasty  | [492ms](https://github.com/patrickhulce/third-party-web/pull/222/files#diff-2af9ab60a9c2f66c4873f6af2d2b07093e03faa8c6d96b24d7fb33acc634209bR1875)  |  495ms | +3ms

We know that this filter has been set to remove from computation scripts with low occurrences, but in some cases (e.g. subdomains) it provides inaccurate public data and ranking which may influence product choice in the wrong way.

We're pleased to get feedbacks and discuss our demonstration to maybe find a more relevant solution that could prevent this kind of issue without misrepresenting all third-parties.