### PR TITLE
refactor: use streams to handle very large query results

### DIFF
--- a/bin/automated-update.js
+++ b/bin/automated-update.js
@@ -23,7 +23,7 @@ const TABLE_REPLACEMENTS = process.env.USE_SAMPLE_DATA
       [process.env.OVERRIDE_HA_LH_TABLE, HA_LH_TABLE_REGEX],
       [process.env.OVERRIDE_HA_REQUESTS_TABLE, HA_REQUESTS_TABLE_REGEX],
       [process.env.OVERRIDE_LH_3P_TABLE, LH_3P_TABLE_REGEX],
-      [process.env.OVERRIDE_LH_PROJECT, LH_REGEX],
+      [process.env.OVERRIDE_LH_PROJECT, LH_PROJECT_REGEX],
     ].filter(([override]) => override)
 
 function getQueryForTable(filename, dateUnderscore) {


### PR DESCRIPTION
This change is required to fix issues with current implementation when bigquery returns very large result.

Issue occurs because of `JSON.stringify` can't be handle very large json results. It throws `RangeError: Invalid string length`. Moving to stream fixes the issue as data is handled row by row (written to file and inserted in db). 

This MR also adds a way to overwrite dataset containing intermediary table (the one where we store mapping between observed domain and canonical one) queried by `entity-per-page.sql`. It'll help in case script runner has no access to dataset hardcoded in sql script (i.e `lighthouse-infrastructure`) 